### PR TITLE
fix: persist sidebar collapse state to localStorage

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -7,12 +7,24 @@ import { useState } from "react";
 import { Outlet } from "react-router-dom";
 import { AppSidebar } from "@/components/layout/AppSidebar";
 
+const STORAGE_KEY = "aero-sidebar-collapsed";
+
 export function AppLayout() {
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState(
+    () => localStorage.getItem(STORAGE_KEY) === "true",
+  );
+
+  const handleToggle = () => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      localStorage.setItem(STORAGE_KEY, String(next));
+      return next;
+    });
+  };
 
   return (
     <div className="flex h-screen overflow-hidden bg-surface">
-      <AppSidebar collapsed={collapsed} onToggle={() => setCollapsed(!collapsed)} />
+      <AppSidebar collapsed={collapsed} onToggle={handleToggle} />
       <main className="flex-1 overflow-y-auto">
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
           <Outlet />


### PR DESCRIPTION
## Summary
- Fixes #41 — sidebar collapse state now persists across page navigations and browser refreshes
- Reads initial state from `localStorage` on mount, saves on every toggle
- Uses `aero-sidebar-collapsed` key, matching existing `aero-*` convention (theme, lang)

## Changes
- `frontend/src/components/layout/AppLayout.tsx` — replaced bare `useState(false)` with localStorage-backed state

## Test plan
- [ ] Toggle sidebar → refresh page → sidebar stays in same state
- [ ] Clear localStorage → sidebar defaults to expanded
- [ ] TypeScript build passes (`tsc -b` — verified locally, zero errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)