### PR TITLE
fix: replace hardcoded map popup labels with i18n keys

### DIFF
--- a/frontend/src/components/maps/OrderMap.tsx
+++ b/frontend/src/components/maps/OrderMap.tsx
@@ -3,6 +3,7 @@
  * Uses react-leaflet v4. CircleMarker avoids broken default icon issue.
  */
 import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
 import {
   MapContainer,
   TileLayer,
@@ -75,6 +76,8 @@ export function OrderMap({
   startLandingSite,
   endLandingSite,
 }: OrderMapProps) {
+  const { t } = useTranslation();
+
   // Determine default center
   let center: LatLngExpression = [51.9, 19.1]; // Poland center fallback
   if (startLandingSite) {
@@ -121,7 +124,7 @@ export function OrderMap({
             }}
           >
             <Popup>
-              <strong>Start:</strong> {startLandingSite.name}
+              <strong>{t('map.startLandingSite')}</strong> {startLandingSite.name}
             </Popup>
           </CircleMarker>
         )}
@@ -139,7 +142,7 @@ export function OrderMap({
             }}
           >
             <Popup>
-              <strong>Lądowisko końcowe:</strong> {endLandingSite.name}
+              <strong>{t('map.endLandingSite')}</strong> {endLandingSite.name}
             </Popup>
           </CircleMarker>
         )}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -301,6 +301,10 @@
     "loadingError": "Loading error",
     "unknownError": "Unknown error"
   },
+  "map": {
+    "startLandingSite": "Start:",
+    "endLandingSite": "End landing site:"
+  },
   "theme": {
     "dark": "Dark",
     "light": "Light"

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -301,6 +301,10 @@
     "loadingError": "Błąd ładowania",
     "unknownError": "Nieznany błąd"
   },
+  "map": {
+    "startLandingSite": "Start:",
+    "endLandingSite": "Lądowisko końcowe:"
+  },
   "theme": {
     "dark": "Ciemny",
     "light": "Jasny"


### PR DESCRIPTION
## Summary
- Fixes #36 — hardcoded Polish/English popup labels in OrderMap now use i18n
- Added `useTranslation` hook to `OrderMap.tsx`
- Added `map.startLandingSite` and `map.endLandingSite` keys to `en.json` and `pl.json`

## Changes
- `frontend/src/components/maps/OrderMap.tsx`
- `frontend/src/locales/en.json`
- `frontend/src/locales/pl.json`

## Test plan
- [ ] Open an order with map → popups show labels in current language
- [ ] Switch language → labels update accordingly
- [ ] TypeScript build passes (verified, zero errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)