### PR TITLE
feat(ui): neon blueprint visual style

### DIFF
--- a/frontend/src/components/layout/AppSidebar.tsx
+++ b/frontend/src/components/layout/AppSidebar.tsx
@@ -112,7 +112,7 @@ export function AppSidebar({ collapsed, onToggle }: AppSidebarProps) {
   return (
     <aside
       className={cn(
-        "flex h-screen flex-col bg-surface-container-low text-on-surface-variant transition-all duration-200 shadow-[1px_0_0_0_rgba(72,162,206,0.08),4px_0_24px_-4px_rgba(0,20,41,0.5)]",
+        "flex h-screen flex-col bg-surface-container-low text-on-surface-variant transition-all duration-200 shadow-[1px_0_0_0_rgba(72,162,206,0.08),4px_0_24px_-4px_rgba(0,20,41,0.5)] border-r border-r-[#48A2CE]/20",
         collapsed ? "w-16" : "w-64"
       )}
     >
@@ -156,7 +156,7 @@ export function AppSidebar({ collapsed, onToggle }: AppSidebarProps) {
                       className={cn(
                         "flex items-center gap-3 rounded-sm px-2 py-2 text-sm font-medium transition-colors",
                         isActive
-                          ? "bg-surface-container-high text-foreground relative before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2 before:h-4 before:w-[3px] before:rounded-full before:bg-accent"
+                          ? "bg-accent/10 text-foreground relative before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2 before:h-4 before:w-[3px] before:rounded-full before:bg-accent border-l-2 border-l-accent shadow-[0_0_8px_rgba(72,162,206,0.15)]"
                           : "text-on-surface-variant hover:bg-surface-container/50 hover:text-foreground",
                         collapsed && "justify-center"
                       )}

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -18,7 +18,7 @@ function Badge({
   return (
     <div
       className={cn(
-        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold transition-all duration-200 hover:scale-105 led-badge",
+        "before:content-[''] before:inline-block before:w-1 before:h-1 before:rounded-full before:bg-current before:mr-1.5 inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold transition-all duration-200 hover:scale-105 led-badge",
         variantClasses[variant],
         className
       )}

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -8,7 +8,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          "bg-gradient-to-br from-primary to-primary-container text-primary-foreground shadow hover:brightness-110 hover:-translate-y-0.5 hover:shadow-[0_4px_12px_rgba(72,162,206,0.15)] active:scale-[0.97]",
+          "bg-surface-container-high text-foreground border-l-[3px] border-l-[#C00017] shadow hover:bg-gradient-to-r hover:from-[#C00017] hover:to-[#93000a] hover:text-white hover:border-l-transparent hover:-translate-y-0.5 hover:shadow-[0_4px_12px_rgba(192,0,23,0.3)] active:scale-[0.97]",
         destructive:
           "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 active:scale-[0.97]",
         outline:

--- a/frontend/src/components/ui/data-table.tsx
+++ b/frontend/src/components/ui/data-table.tsx
@@ -113,7 +113,7 @@ export function DataTable<T>({
       {filter && <div className="mb-4">{filter}</div>}
 
       {/* ---------- Table ---------- */}
-      <div className="rounded-md bg-surface-container-low shadow-[0_0_24px_rgba(0,20,41,0.3)] border border-accent/5">
+      <div className="rounded-md bg-surface-container-low border border-[#48A2CE]/15 shadow-[inset_0_0_12px_rgba(72,162,206,0.02),0_0_24px_rgba(0,20,41,0.3)]">
         <Table>
           <TableHeader>
             <TableRow>

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -21,7 +21,7 @@ const TableHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <thead
     ref={ref}
-    className={cn("[&_tr]:border-b [&_tr]:border-outline-variant", className)}
+    className={cn("[&_tr]:border-b [&_tr]:border-[#48A2CE]/20", className)}
     {...props}
   />
 ));

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -93,9 +93,10 @@
 /* Cockpit atmosphere */
 .cockpit-grid {
   background-image:
-    linear-gradient(rgba(72,162,206,0.03) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(72,162,206,0.03) 1px, transparent 1px);
-  background-size: 40px 40px;
+    linear-gradient(rgba(72,162,206,0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(72,162,206,0.05) 1px, transparent 1px),
+    radial-gradient(circle 1px at center, rgba(72,162,206,0.04) 1px, transparent 1px);
+  background-size: 32px 32px, 32px 32px, 32px 32px;
   animation: grid-breathe 8s ease-in-out infinite;
 }
 .cockpit-glow {
@@ -118,9 +119,10 @@
 }
 .light .cockpit-grid {
   background-image:
-    linear-gradient(rgba(0,48,100,0.04) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(0,48,100,0.04) 1px, transparent 1px);
-  background-size: 40px 40px;
+    linear-gradient(rgba(0,48,100,0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(0,48,100,0.05) 1px, transparent 1px),
+    radial-gradient(circle 1px at center, rgba(0,48,100,0.04) 1px, transparent 1px);
+  background-size: 32px 32px, 32px 32px, 32px 32px;
 }
 .light .cockpit-glow {
   background: radial-gradient(ellipse 40% 80% at 0% 50%, rgba(0,48,100,0.02), transparent 70%);


### PR DESCRIPTION
## Summary

Implements Proposal C "Neon Blueprint" — engineering precision aesthetic for internal pages.

### Changes
- **Blueprint grid**: 32px spacing with dot intersections at line crossings (5% opacity, breathing animation)
- **Table outline**: Neon blue border (#48A2CE/15) with subtle inner glow
- **Table header**: Blue neon separator line (#48A2CE/20)
- **LED dot badges**: Small currentColor dot before badge text (before: pseudo-element)
- **Button style**: Left-accent (3px red border) with hover fill reveal (red gradient)
- **Sidebar**: Neon blue right edge border, active item with blue glow shadow

### No fictional elements
- Zero Stitch inventions (Privacy Policy, Dashboard Stats, Settings, etc.)
- Only existing app features styled

### Light theme
- Grid and glow overrides included for light mode

## Test plan
- [x] `npm run build` — zero errors
- [x] `npx playwright test` — 25/25 passed
- [x] `grep` for fictional elements — 0 matches
- [ ] CI — waiting for green

🤖 Generated with [Claude Code](https://claude.com/claude-code)