### PR TITLE
fix: add date ordering validation (closes #51, #55)

### DIFF
--- a/backend/app/api/operations.py
+++ b/backend/app/api/operations.py
@@ -352,6 +352,20 @@ async def update_operation(
     for field, new_val in update_data.items():
         setattr(op, field, new_val)
 
+    # Post-merge date ordering validation
+    if op.proposed_date_earliest and op.proposed_date_latest:
+        if op.proposed_date_latest < op.proposed_date_earliest:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="proposed_date_latest must not be before proposed_date_earliest",
+            )
+    if op.planned_date_earliest and op.planned_date_latest:
+        if op.planned_date_latest < op.planned_date_earliest:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="planned_date_latest must not be before planned_date_earliest",
+            )
+
     # Write audit log entries in same transaction
     _create_audit_entries(op.id, current_user.id, changes, db)
 

--- a/backend/app/api/orders.py
+++ b/backend/app/api/orders.py
@@ -419,6 +419,19 @@ async def update_order(
         if field in update_data:
             setattr(order, field, update_data[field])
 
+    # Post-merge date ordering validation
+    if order.planned_end_datetime <= order.planned_start_datetime:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="planned_end_datetime must be after planned_start_datetime",
+        )
+    if order.actual_start_datetime and order.actual_end_datetime:
+        if order.actual_end_datetime <= order.actual_start_datetime:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="actual_end_datetime must be after actual_start_datetime",
+            )
+
     # Update M:N relationships if provided (eagerly load first to avoid MissingGreenlet)
     if "crew_member_ids" in update_data or "operation_ids" in update_data:
         await db.refresh(order, ["operations", "crew_members"])

--- a/backend/app/schemas/flight_operation.py
+++ b/backend/app/schemas/flight_operation.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 VALID_ACTIVITY_TYPES = [
@@ -93,6 +93,18 @@ class OperationCreate(BaseModel):
                 raise ValueError(f"Invalid email: {email}")
         return v
 
+    @model_validator(mode="after")
+    def check_proposed_dates(self) -> OperationCreate:
+        if (
+            self.proposed_date_earliest is not None
+            and self.proposed_date_latest is not None
+            and self.proposed_date_latest < self.proposed_date_earliest
+        ):
+            raise ValueError(
+                "proposed_date_latest must not be before proposed_date_earliest"
+            )
+        return self
+
 
 class OperationUpdate(BaseModel):
     """Schema for updating a flight operation — all fields optional."""
@@ -171,6 +183,26 @@ class OperationUpdate(BaseModel):
                 raise ValueError(f"Invalid email: {email}")
         return v
 
+    @model_validator(mode="after")
+    def check_date_ordering(self) -> OperationUpdate:
+        if (
+            self.proposed_date_earliest is not None
+            and self.proposed_date_latest is not None
+            and self.proposed_date_latest < self.proposed_date_earliest
+        ):
+            raise ValueError(
+                "proposed_date_latest must not be before proposed_date_earliest"
+            )
+        if (
+            self.planned_date_earliest is not None
+            and self.planned_date_latest is not None
+            and self.planned_date_latest < self.planned_date_earliest
+        ):
+            raise ValueError(
+                "planned_date_latest must not be before planned_date_earliest"
+            )
+        return self
+
 
 # ── Response sub-models ─────────────────────────────────────────────
 
@@ -204,6 +236,14 @@ class ConfirmRequest(BaseModel):
 
     planned_date_earliest: datetime.date
     planned_date_latest: datetime.date
+
+    @model_validator(mode="after")
+    def check_planned_dates(self) -> ConfirmRequest:
+        if self.planned_date_latest < self.planned_date_earliest:
+            raise ValueError(
+                "planned_date_latest must not be before planned_date_earliest"
+            )
+        return self
 
 
 class CommentCreate(BaseModel):

--- a/backend/app/schemas/flight_order.py
+++ b/backend/app/schemas/flight_order.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import datetime
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 
 STATUS_LABELS: dict[int, str] = {
     1: "Wprowadzone",
@@ -54,6 +54,14 @@ class FlightOrderCreate(BaseModel):
     operation_ids: list[int]
     estimated_route_km: int
 
+    @model_validator(mode="after")
+    def check_planned_dates(self) -> FlightOrderCreate:
+        if self.planned_end_datetime <= self.planned_start_datetime:
+            raise ValueError(
+                "planned_end_datetime must be after planned_start_datetime"
+            )
+        return self
+
 
 class FlightOrderUpdate(BaseModel):
     """Schema for updating a flight order — all fields optional."""
@@ -68,6 +76,26 @@ class FlightOrderUpdate(BaseModel):
     estimated_route_km: Optional[int] = None
     actual_start_datetime: Optional[datetime.datetime] = None
     actual_end_datetime: Optional[datetime.datetime] = None
+
+    @model_validator(mode="after")
+    def check_date_ordering(self) -> FlightOrderUpdate:
+        if (
+            self.planned_start_datetime is not None
+            and self.planned_end_datetime is not None
+            and self.planned_end_datetime <= self.planned_start_datetime
+        ):
+            raise ValueError(
+                "planned_end_datetime must be after planned_start_datetime"
+            )
+        if (
+            self.actual_start_datetime is not None
+            and self.actual_end_datetime is not None
+            and self.actual_end_datetime <= self.actual_start_datetime
+        ):
+            raise ValueError(
+                "actual_end_datetime must be after actual_start_datetime"
+            )
+        return self
 
 
 # ── Response ─────────────────────────────────────────────────────────

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -239,7 +239,9 @@
     "validationOrderNumberRequired": "Order number is required",
     "validationShortDescriptionRequired": "Short description is required",
     "validationActivityTypeRequired": "Select at least one activity type",
-    "kmlUploadAfterCreate": "KML file (route) is required. After creating the operation you will be redirected to the detail page where you can upload the KML file."
+    "kmlUploadAfterCreate": "KML file (route) is required. After creating the operation you will be redirected to the detail page where you can upload the KML file.",
+    "validationProposedDateOrder": "'To' date must not be before 'from' date",
+    "validationPlannedDateOrder": "Planned 'to' date must not be before 'from' date"
   },
   "orders": {
     "title": "Flight Orders",
@@ -318,7 +320,9 @@
     "confirmNotCompleted": "Confirm not completed",
     "confirmNotCompletedDesc": "Are you sure you want to mark this order as not completed?",
     "loadingError": "Loading error",
-    "unknownError": "Unknown error"
+    "unknownError": "Unknown error",
+    "validationPlannedEndBeforeStart": "End date must be after start date",
+    "validationActualEndBeforeStart": "Actual end must be after actual start"
   },
   "theme": {
     "dark": "Dark",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -240,7 +240,9 @@
     "validationOrderNumberRequired": "Nr zlecenia jest wymagany",
     "validationShortDescriptionRequired": "Krótki opis jest wymagany",
     "validationActivityTypeRequired": "Wybierz co najmniej jeden rodzaj czynności",
-    "kmlUploadAfterCreate": "Plik KML (trasa) jest wymagany. Po utworzeniu operacji zostaniesz przekierowany do strony szczegółów, gdzie możesz przesłać plik KML."
+    "kmlUploadAfterCreate": "Plik KML (trasa) jest wymagany. Po utworzeniu operacji zostaniesz przekierowany do strony szczegółów, gdzie możesz przesłać plik KML.",
+    "validationProposedDateOrder": "Data 'do' nie może być wcześniejsza niż data 'od'",
+    "validationPlannedDateOrder": "Planowana data 'do' nie może być wcześniejsza niż data 'od'"
   },
   "orders": {
     "title": "Zlecenia lotnicze",
@@ -319,7 +321,9 @@
     "confirmNotCompleted": "Potwierdź brak realizacji",
     "confirmNotCompletedDesc": "Czy na pewno chcesz oznaczyć to zlecenie jako niezrealizowane?",
     "loadingError": "Błąd ładowania",
-    "unknownError": "Nieznany błąd"
+    "unknownError": "Nieznany błąd",
+    "validationPlannedEndBeforeStart": "Data końca musi być późniejsza niż data startu",
+    "validationActualEndBeforeStart": "Rzeczywisty koniec musi być późniejszy niż rzeczywisty start"
   },
   "theme": {
     "dark": "Ciemny",

--- a/frontend/src/pages/operations/OperationCreateForm.tsx
+++ b/frontend/src/pages/operations/OperationCreateForm.tsx
@@ -67,6 +67,8 @@ export function OperationCreateForm({
 }: OperationCreateFormProps) {
   const { t } = useTranslation();
 
+  const proposedDateError = !!(proposedDateEarliest && proposedDateLatest && proposedDateLatest < proposedDateEarliest);
+
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <div className="rounded-md bg-surface-container-low p-6">
@@ -160,6 +162,9 @@ export function OperationCreateForm({
               />
             </div>
           </div>
+          {proposedDateError && (
+            <p className="text-sm text-destructive-foreground">{t('operations.validationProposedDateOrder')}</p>
+          )}
 
           <div className="rounded-md bg-blue-500/10 border border-blue-500/30 p-3">
             <p className="text-sm text-blue-400">
@@ -168,7 +173,7 @@ export function OperationCreateForm({
           </div>
 
           <div className="flex gap-3 pt-2">
-            <Button type="submit" disabled={isSaving}>
+            <Button type="submit" disabled={isSaving || proposedDateError}>
               {isSaving
                 ? t('operations.saving')
                 : t('operations.createOperation')}

--- a/frontend/src/pages/operations/OperationDetailView.tsx
+++ b/frontend/src/pages/operations/OperationDetailView.tsx
@@ -170,6 +170,9 @@ export function OperationDetailView({
 }: OperationDetailViewProps) {
   const { t } = useTranslation();
 
+  const proposedDateError = !!(proposedDateEarliest && proposedDateLatest && proposedDateLatest < proposedDateEarliest);
+  const plannedDateError = !!(plannedDateEarliest && plannedDateLatest && plannedDateLatest < plannedDateEarliest);
+
   return (
     <>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -289,6 +292,10 @@ export function OperationDetailView({
               </div>
             </div>
 
+            {proposedDateError && (
+              <p className="text-sm text-destructive-foreground">{t('operations.validationProposedDateOrder')}</p>
+            )}
+
             {/* Planned dates — editable ONLY by Supervisor in detail mode */}
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
@@ -315,9 +322,13 @@ export function OperationDetailView({
               </div>
             </div>
 
+            {plannedDateError && (
+              <p className="text-sm text-destructive-foreground">{t('operations.validationPlannedDateOrder')}</p>
+            )}
+
             {canEdit && (
               <div className="flex gap-3 pt-2">
-                <Button type="submit" disabled={isSaving}>
+                <Button type="submit" disabled={isSaving || proposedDateError || plannedDateError}>
                   {isSaving
                     ? t('operations.saving')
                     : t('operations.saveChanges')}

--- a/frontend/src/pages/operations/OperationListPage.tsx
+++ b/frontend/src/pages/operations/OperationListPage.tsx
@@ -75,6 +75,7 @@ export function OperationListPage() {
   const [confirmOpId, setConfirmOpId] = useState<number | null>(null);
   const [confirmPlannedEarliest, setConfirmPlannedEarliest] = useState("");
   const [confirmPlannedLatest, setConfirmPlannedLatest] = useState("");
+  const confirmDateError = !!(confirmPlannedEarliest && confirmPlannedLatest && confirmPlannedLatest < confirmPlannedEarliest);
 
   const queryParams = statusFilter ? `?op_status=${statusFilter}` : "";
 
@@ -354,6 +355,9 @@ export function OperationListPage() {
               />
             </div>
           </div>
+          {confirmDateError && (
+            <p className="text-sm text-destructive-foreground">{t('operations.validationPlannedDateOrder')}</p>
+          )}
           <DialogFooter>
             <Button variant="ghost" onClick={() => setConfirmOpId(null)}>
               {t('common.cancel')}
@@ -364,7 +368,8 @@ export function OperationListPage() {
               disabled={
                 confirmMutation.isPending ||
                 !confirmPlannedEarliest ||
-                !confirmPlannedLatest
+                !confirmPlannedLatest ||
+                confirmDateError
               }
             >
               {confirmMutation.isPending

--- a/frontend/src/pages/orders/OrderCreateForm.tsx
+++ b/frontend/src/pages/orders/OrderCreateForm.tsx
@@ -157,6 +157,8 @@ export function OrderCreateForm({
   const createEndSite = landingSites.find((s) => s.id === Number(endSiteId));
   const hasMapData = createMapOps.length > 0 || createStartSite || createEndSite;
 
+  const dateError = !!(plannedStart && plannedEnd && new Date(plannedEnd) <= new Date(plannedStart));
+
   return (
     <div className="rounded-md bg-surface-container-low p-6">
       <form onSubmit={onSubmit} className="space-y-5">
@@ -189,6 +191,9 @@ export function OrderCreateForm({
             />
           </div>
         </div>
+        {dateError && (
+          <p className="text-sm text-destructive-foreground">{t('orders.validationPlannedEndBeforeStart')}</p>
+        )}
 
         {/* Helicopter dropdown */}
         <div className="space-y-2">
@@ -393,7 +398,7 @@ export function OrderCreateForm({
         )}
 
         <div className="flex gap-3 pt-2">
-          <Button type="submit" disabled={isCreating}>
+          <Button type="submit" disabled={isCreating || dateError}>
             {isCreating
               ? t('orders.creating')
               : t('orders.createOrder')}

--- a/frontend/src/pages/orders/OrderDetailView.tsx
+++ b/frontend/src/pages/orders/OrderDetailView.tsx
@@ -93,6 +93,8 @@ export function OrderDetailView({
 }: OrderDetailViewProps) {
   const { t } = useTranslation();
 
+  const actualDateError = !!(actualStart && actualEnd && new Date(actualEnd) <= new Date(actualStart));
+
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
       {/* Left: Order details */}
@@ -191,9 +193,12 @@ export function OrderDetailView({
                 />
               </div>
             </div>
+            {actualDateError && (
+              <p className="text-sm text-destructive-foreground">{t('orders.validationActualEndBeforeStart')}</p>
+            )}
             <Button
               onClick={onSaveActualTimes}
-              disabled={savingActualTimes}
+              disabled={savingActualTimes || actualDateError}
             >
               {savingActualTimes
                 ? t('orders.savingTimes')


### PR DESCRIPTION
## Summary
- **Backend**: Added Pydantic `model_validator` on all date-pair schemas (`FlightOrderCreate`, `FlightOrderUpdate`, `OperationCreate`, `OperationUpdate`, `ConfirmRequest`). Added post-merge validation in update endpoints for partial updates.
- **Frontend**: Inline error messages + disabled submit buttons on all 5 affected forms (OrderCreate, OrderDetail actual times, OperationCreate, OperationDetail, OperationList confirm dialog).
- **Translations**: Added 4 new i18n keys (PL + EN) for date validation messages.

Closes #51, Closes #55

## Test plan
- [ ] Create flight order with end before start → blocked on frontend, 422 from backend
- [ ] Create operation with proposed_date_latest < earliest → blocked + 422
- [ ] Confirm operation with planned latest < earliest → blocked + 422
- [ ] Update order actual times with end < start → blocked + 422
- [ ] Partial update (only one date) → allowed
- [ ] Same-day dates on operations → allowed

🤖 Generated with [Claude Code](https://claude.com/claude-code)