### PR TITLE
fix: reject empty order_number on operation update (closes #52)

### DIFF
--- a/backend/app/api/operations.py
+++ b/backend/app/api/operations.py
@@ -331,6 +331,13 @@ async def update_operation(
 
     update_data = body.model_dump(exclude_unset=True)
 
+    # Reject explicit null for required fields
+    if "order_number" in update_data and update_data["order_number"] is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="order_number cannot be cleared",
+        )
+
     # Planner cannot modify locked fields — silently strip them
     if current_user.system_role == "Osoba planująca":
         for field in PLANNER_LOCKED_FIELDS:

--- a/backend/app/schemas/flight_operation.py
+++ b/backend/app/schemas/flight_operation.py
@@ -127,6 +127,8 @@ class OperationUpdate(BaseModel):
         if v is None:
             return v
         v = v.strip()
+        if not v:
+            raise ValueError("order_number must not be empty")
         if len(v) > 30:
             raise ValueError("must be 30 characters or fewer")
         return v


### PR DESCRIPTION
## Summary
- Backend `OperationUpdate` validator rejects empty/whitespace `order_number` after stripping
- Update endpoint guards against explicit `null` for `order_number`

Closes #52

## Test plan
- [ ] Update operation with empty order_number → 422
- [ ] Update operation with whitespace-only order_number → 422
- [ ] Update operation with valid order_number → succeeds
- [ ] Update operation without sending order_number field → succeeds (no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)