### PR TITLE
fix: add required field legend to operation forms (closes #53)

### DIFF
--- a/frontend/src/components/ui/FormLegend.tsx
+++ b/frontend/src/components/ui/FormLegend.tsx
@@ -1,0 +1,10 @@
+import { useTranslation } from "react-i18next";
+
+export function FormLegend() {
+  const { t } = useTranslation();
+  return (
+    <p className="text-xs text-muted-foreground mb-4">
+      * — {t('common.requiredField')}
+    </p>
+  );
+}

--- a/frontend/src/locales/en.json
+++ b/frontend/src/locales/en.json
@@ -23,7 +23,8 @@
     "saveChanges": "Save changes",
     "invalidValue": "Invalid value",
     "loadingError": "Loading error",
-    "unknownError": "Unknown error"
+    "unknownError": "Unknown error",
+    "requiredField": "required field"
   },
   "sidebar": {
     "admin": "Administration",

--- a/frontend/src/locales/pl.json
+++ b/frontend/src/locales/pl.json
@@ -23,7 +23,8 @@
     "saveChanges": "Zapisz zmiany",
     "invalidValue": "Nieprawidłowa wartość",
     "loadingError": "Błąd ładowania",
-    "unknownError": "Nieznany błąd"
+    "unknownError": "Nieznany błąd",
+    "requiredField": "pole wymagane"
   },
   "sidebar": {
     "admin": "Administracja",

--- a/frontend/src/pages/operations/OperationCreateForm.tsx
+++ b/frontend/src/pages/operations/OperationCreateForm.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
+import { FormLegend } from "@/components/ui/FormLegend";
 
 // ── Constants ──────────────────────────────────────────────────────
 
@@ -71,6 +72,7 @@ export function OperationCreateForm({
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <div className="rounded-md bg-surface-container-low p-6">
         <form onSubmit={onSubmit} className="space-y-4">
+          <FormLegend />
           <div className="space-y-2">
             <Label htmlFor="orderNumber">{t('operations.orderNumber')} *</Label>
             <Input

--- a/frontend/src/pages/operations/OperationDetailView.tsx
+++ b/frontend/src/pages/operations/OperationDetailView.tsx
@@ -22,6 +22,7 @@ import {
 } from "@/components/ui/table";
 import { OperationMap } from "@/components/maps/OperationMap";
 import { Upload } from "lucide-react";
+import { FormLegend } from "@/components/ui/FormLegend";
 
 // ── Constants ──────────────────────────────────────────────────────
 
@@ -176,6 +177,7 @@ export function OperationDetailView({
         {/* Left: Form fields */}
         <div className="rounded-md bg-surface-container-low p-6">
           <form onSubmit={onSubmit} className="space-y-4">
+            <FormLegend />
             <div className="space-y-2">
               <Label htmlFor="orderNumber">{t('operations.orderNumber')} *</Label>
               <Input


### PR DESCRIPTION
## Summary
- New `FormLegend` component shows `* — pole wymagane` above forms with asterisked fields
- Added to `OperationCreateForm` and `OperationDetailView`
- Translation keys added (PL + EN)

Closes #53

## Test plan
- [ ] Open "Nowa operacja lotnicza" form → legend visible above fields
- [ ] Open existing operation detail → legend visible above fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)