### PR TITLE
fix: hide planned dates when empty for non-supervisor users (closes #54)

### DIFF
--- a/frontend/src/pages/operations/OperationDetailView.tsx
+++ b/frontend/src/pages/operations/OperationDetailView.tsx
@@ -289,31 +289,33 @@ export function OperationDetailView({
               </div>
             </div>
 
-            {/* Planned dates — editable ONLY by Supervisor in detail mode */}
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="plannedDateEarliest">
-                  {t('operations.plannedDateFrom')}
-                </Label>
-                <Input
-                  id="plannedDateEarliest"
-                  type="date"
-                  value={plannedDateEarliest}
-                  onChange={(e) => onPlannedDateEarliestChange(e.target.value)}
-                  disabled={!isSupervisor}
-                />
+            {/* Planned dates — shown for Supervisor or when dates exist */}
+            {(isSupervisor || operation.planned_date_earliest || operation.planned_date_latest) && (
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="plannedDateEarliest">
+                    {t('operations.plannedDateFrom')}
+                  </Label>
+                  <Input
+                    id="plannedDateEarliest"
+                    type="date"
+                    value={plannedDateEarliest}
+                    onChange={(e) => onPlannedDateEarliestChange(e.target.value)}
+                    disabled={!isSupervisor}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="plannedDateLatest">{t('operations.plannedDateTo')}</Label>
+                  <Input
+                    id="plannedDateLatest"
+                    type="date"
+                    value={plannedDateLatest}
+                    onChange={(e) => onPlannedDateLatestChange(e.target.value)}
+                    disabled={!isSupervisor}
+                  />
+                </div>
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="plannedDateLatest">{t('operations.plannedDateTo')}</Label>
-                <Input
-                  id="plannedDateLatest"
-                  type="date"
-                  value={plannedDateLatest}
-                  onChange={(e) => onPlannedDateLatestChange(e.target.value)}
-                  disabled={!isSupervisor}
-                />
-              </div>
-            </div>
+            )}
 
             {canEdit && (
               <div className="flex gap-3 pt-2">


### PR DESCRIPTION
## Summary
- Planned dates section in `OperationDetailView` is now conditionally rendered
- Shown only when user is Supervisor OR when dates have actual values
- Prevents confusing empty date fields for newly created operations

Closes #54

## Test plan
- [ ] Create operation as Planner → detail view does NOT show empty planned dates
- [ ] Supervisor views same operation → planned dates section IS visible
- [ ] Operation with confirmed dates → planned dates visible for all roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)