### PR TITLE
fix: hide planned dates when empty for non-supervisor users (closes #54)

### DIFF
--- a/frontend/src/pages/operations/OperationDetailView.tsx
+++ b/frontend/src/pages/operations/OperationDetailView.tsx
@@ -298,31 +298,33 @@ export function OperationDetailView({
               <p className="text-sm text-destructive-foreground">{t('operations.validationProposedDateOrder')}</p>
             )}
 
-            {/* Planned dates — editable ONLY by Supervisor in detail mode */}
-            <div className="grid grid-cols-2 gap-4">
-              <div className="space-y-2">
-                <Label htmlFor="plannedDateEarliest">
-                  {t('operations.plannedDateFrom')}
-                </Label>
-                <Input
-                  id="plannedDateEarliest"
-                  type="date"
-                  value={plannedDateEarliest}
-                  onChange={(e) => onPlannedDateEarliestChange(e.target.value)}
-                  disabled={!isSupervisor}
-                />
+            {/* Planned dates — shown for Supervisor or when dates exist */}
+            {(isSupervisor || operation.planned_date_earliest || operation.planned_date_latest) && (
+              <div className="grid grid-cols-2 gap-4">
+                <div className="space-y-2">
+                  <Label htmlFor="plannedDateEarliest">
+                    {t('operations.plannedDateFrom')}
+                  </Label>
+                  <Input
+                    id="plannedDateEarliest"
+                    type="date"
+                    value={plannedDateEarliest}
+                    onChange={(e) => onPlannedDateEarliestChange(e.target.value)}
+                    disabled={!isSupervisor}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="plannedDateLatest">{t('operations.plannedDateTo')}</Label>
+                  <Input
+                    id="plannedDateLatest"
+                    type="date"
+                    value={plannedDateLatest}
+                    onChange={(e) => onPlannedDateLatestChange(e.target.value)}
+                    disabled={!isSupervisor}
+                  />
+                </div>
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="plannedDateLatest">{t('operations.plannedDateTo')}</Label>
-                <Input
-                  id="plannedDateLatest"
-                  type="date"
-                  value={plannedDateLatest}
-                  onChange={(e) => onPlannedDateLatestChange(e.target.value)}
-                  disabled={!isSupervisor}
-                />
-              </div>
-            </div>
+            )}
 
             {plannedDateError && (
               <p className="text-sm text-destructive-foreground">{t('operations.validationPlannedDateOrder')}</p>


### PR DESCRIPTION
## Summary
- Planned dates section in OperationDetailView conditionally rendered
- Shown only when user is Supervisor OR when dates have actual values
- Rebased on master after #64 merge, conflicts resolved

Closes #54

## Test plan
- [ ] Create operation as Planner → no empty planned dates shown
- [ ] Supervisor views same operation → planned dates visible
- [ ] Operation with confirmed dates → visible for all roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)