### PR TITLE
fix(ui): increase neon blueprint grid visibility

### DIFF
--- a/frontend/src/components/ui/data-table.tsx
+++ b/frontend/src/components/ui/data-table.tsx
@@ -113,7 +113,7 @@ export function DataTable<T>({
       {filter && <div className="mb-4">{filter}</div>}
 
       {/* ---------- Table ---------- */}
-      <div className="rounded-md bg-surface-container-low border border-[#48A2CE]/15 shadow-[inset_0_0_12px_rgba(72,162,206,0.02),0_0_24px_rgba(0,20,41,0.3)]">
+      <div className="rounded-md bg-surface-container-low border border-[#48A2CE]/25 shadow-[inset_0_0_20px_rgba(72,162,206,0.04),0_0_30px_rgba(0,20,41,0.4)]">
         <Table>
           <TableHeader>
             <TableRow>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -93,14 +93,14 @@
 /* Cockpit atmosphere */
 .cockpit-grid {
   background-image:
-    linear-gradient(rgba(72,162,206,0.05) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(72,162,206,0.05) 1px, transparent 1px),
-    radial-gradient(circle 1px at center, rgba(72,162,206,0.04) 1px, transparent 1px);
+    linear-gradient(rgba(72,162,206,0.12) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(72,162,206,0.12) 1px, transparent 1px),
+    radial-gradient(circle 1.5px at center, rgba(72,162,206,0.15) 1.5px, transparent 1.5px);
   background-size: 32px 32px, 32px 32px, 32px 32px;
   animation: grid-breathe 8s ease-in-out infinite;
 }
 .cockpit-glow {
-  background: radial-gradient(ellipse 40% 80% at 0% 50%, rgba(72,162,206,0.03), transparent 70%);
+  background: radial-gradient(ellipse 50% 80% at 0% 50%, rgba(72,162,206,0.06), transparent 70%);
 }
 @keyframes grid-breathe {
   0%, 100% { opacity: 0.6; }


### PR DESCRIPTION
Grid and neon effects were too subtle (5% opacity on dark navy = nearly invisible).

Increased:
- Grid lines: 5% → 12%
- Grid dots: 4% → 15%, 1px → 1.5px
- Cockpit glow: 3% → 6%
- Table neon border: 15% → 25%
- Table inner glow: 2% → 4%

Verified via Playwright screenshots. E2e: 25/25 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)