### PR TITLE
fix(ui): grid background was invisible — CSS cascade override

### DIFF
--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -15,10 +15,10 @@ export function AppLayout() {
   }, [collapsed]);
 
   return (
-    <div className="flex h-screen overflow-hidden bg-surface">
-      <div className="pointer-events-none fixed inset-0 cockpit-grid cockpit-glow" />
+    <div className="flex h-screen overflow-hidden">
+      <div className="pointer-events-none fixed inset-0 z-0 cockpit-grid" />
       <AppSidebar collapsed={collapsed} onToggle={() => setCollapsed(!collapsed)} />
-      <main className="flex-1 overflow-y-auto">
+      <main className="relative z-10 flex-1 overflow-y-auto bg-transparent">
         <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
           <Outlet />
         </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -93,14 +93,12 @@
 /* Cockpit atmosphere */
 .cockpit-grid {
   background-image:
+    radial-gradient(ellipse 50% 80% at 0% 50%, rgba(72,162,206,0.06), transparent 70%),
     linear-gradient(rgba(72,162,206,0.12) 1px, transparent 1px),
     linear-gradient(90deg, rgba(72,162,206,0.12) 1px, transparent 1px),
     radial-gradient(circle 1.5px at center, rgba(72,162,206,0.15) 1.5px, transparent 1.5px);
-  background-size: 32px 32px, 32px 32px, 32px 32px;
+  background-size: 100% 100%, 32px 32px, 32px 32px, 32px 32px;
   animation: grid-breathe 8s ease-in-out infinite;
-}
-.cockpit-glow {
-  background: radial-gradient(ellipse 50% 80% at 0% 50%, rgba(72,162,206,0.06), transparent 70%);
 }
 @keyframes grid-breathe {
   0%, 100% { opacity: 0.6; }
@@ -119,11 +117,9 @@
 }
 .light .cockpit-grid {
   background-image:
+    radial-gradient(ellipse 50% 80% at 0% 50%, rgba(0,48,100,0.03), transparent 70%),
     linear-gradient(rgba(0,48,100,0.05) 1px, transparent 1px),
     linear-gradient(90deg, rgba(0,48,100,0.05) 1px, transparent 1px),
-    radial-gradient(circle 1px at center, rgba(0,48,100,0.04) 1px, transparent 1px);
-  background-size: 32px 32px, 32px 32px, 32px 32px;
-}
-.light .cockpit-glow {
-  background: radial-gradient(ellipse 40% 80% at 0% 50%, rgba(0,48,100,0.02), transparent 70%);
+    radial-gradient(circle 1.5px at center, rgba(0,48,100,0.04) 1.5px, transparent 1.5px);
+  background-size: 100% 100%, 32px 32px, 32px 32px, 32px 32px;
 }


### PR DESCRIPTION
## Root cause

Two CSS classes (`.cockpit-grid` and `.cockpit-glow`) both set `background-image` on the same div. CSS cascade made the last one (glow) override the first (grid lines), so **grid was never visible**.

## Fix

Merged all background layers into single `.cockpit-grid` class with multiple `background-image` values. Removed `.cockpit-glow`. Fixed z-index layering (main bg-transparent, grid z-0).

## Verified

- Playwright screenshot confirms grid lines visible
- E2e: 25/25 pass
- Light theme override updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)