### PR TITLE
docs: AERO Townhall presentation (Claude Design handoff)

### DIFF
--- a/docs/AERO_Townhall.html
+++ b/docs/AERO_Townhall.html
@@ -1,0 +1,1751 @@
+<!doctype html>
+<html lang="pl">
+<head>
+<meta charset="utf-8" />
+<title>AERO — Townhall · 2 dni, 2 non-devs, 1 system lotniczy</title>
+<meta name="viewport" content="width=1920" />
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+<script>
+/**
+ * <deck-stage> — reusable web component for HTML decks.
+ *
+ * Handles:
+ *  (a) speaker notes — reads <script type="application/json" id="speaker-notes">
+ *      and posts {slideIndexChanged: N} to the parent window on nav.
+ *  (b) keyboard navigation — ←/→, PgUp/PgDn, Space, Home/End, number keys.
+ *  (c) press R to reset to slide 0 (with a tasteful keyboard hint).
+ *  (d) bottom-center overlay showing slide count + hints, fades out on idle.
+ *  (e) auto-scaling — inner canvas is a fixed design size (default 1920×1080)
+ *      scaled with `transform: scale()` to fit the viewport, letterboxed.
+ *      Set the `noscale` attribute to render at authored size (1:1) — the
+ *      PPTX exporter sets this so its DOM capture sees unscaled geometry.
+ *  (f) print — `@media print` lays every slide out as its own page at the
+ *      design size, so the browser's Print → Save as PDF produces a clean
+ *      one-page-per-slide PDF with no extra setup.
+ *
+ * Slides are HIDDEN, not unmounted. Non-active slides stay in the DOM with
+ * `visibility: hidden` + `opacity: 0`, so their state (videos, iframes,
+ * form inputs, React trees) is preserved across navigation.
+ *
+ * Lifecycle event — the component dispatches a `slidechange` CustomEvent on
+ * itself whenever the active slide changes (including the initial mount).
+ * The event bubbles and composes out of shadow DOM, so you can listen on
+ * the <deck-stage> element or on document:
+ *
+ *   document.querySelector('deck-stage').addEventListener('slidechange', (e) => {
+ *     e.detail.index         // new 0-based index
+ *     e.detail.previousIndex // previous index, or -1 on init
+ *     e.detail.total         // total slide count
+ *     e.detail.slide         // the new active slide element
+ *     e.detail.previousSlide // the prior slide element, or null on init
+ *     e.detail.reason        // 'init' | 'keyboard' | 'click' | 'tap' | 'api'
+ *   });
+ *
+ * Persistence: current slide index is saved to localStorage keyed by the
+ * document path, so refresh returns you to the same place.
+ *
+ * Usage:
+ *   <deck-stage width="1920" height="1080">
+ *     <section data-label="Title">...</section>
+ *     <section data-label="Agenda">...</section>
+ *   </deck-stage>
+ *
+ * Slides are the direct element children of <deck-stage>. Each slide is
+ * automatically tagged with:
+ *   - data-screen-label="NN Label"   (1-indexed, for comment flow)
+ *   - data-om-validate="no_overflowing_text,no_overlapping_text,slide_sized_text"
+ */
+
+(() => {
+  const DESIGN_W_DEFAULT = 1920;
+  const DESIGN_H_DEFAULT = 1080;
+  const STORAGE_PREFIX = 'deck-stage:slide:';
+  const OVERLAY_HIDE_MS = 1800;
+  const VALIDATE_ATTR = 'no_overflowing_text,no_overlapping_text,slide_sized_text';
+
+  const pad2 = (n) => String(n).padStart(2, '0');
+
+  const stylesheet = `
+    :host {
+      position: fixed;
+      inset: 0;
+      display: block;
+      background: #000;
+      color: #fff;
+      font-family: -apple-system, BlinkMacSystemFont, "Helvetica Neue", Helvetica, Arial, sans-serif;
+      overflow: hidden;
+    }
+
+    .stage {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .canvas {
+      position: relative;
+      transform-origin: center center;
+      flex-shrink: 0;
+      background: #fff;
+      will-change: transform;
+    }
+
+    /* Slides live in light DOM (via <slot>) so authored CSS still applies.
+       We absolutely position each slotted child to stack them. */
+    ::slotted(*) {
+      position: absolute !important;
+      inset: 0 !important;
+      width: 100% !important;
+      height: 100% !important;
+      box-sizing: border-box !important;
+      overflow: hidden;
+      opacity: 0;
+      pointer-events: none;
+      visibility: hidden;
+    }
+    ::slotted([data-deck-active]) {
+      opacity: 1;
+      pointer-events: auto;
+      visibility: visible;
+    }
+
+    /* Tap zones for mobile — back/forward thirds like Stories.
+       Transparent, no visible UI, don't block the overlay. */
+    .tapzones {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      z-index: 2147482000;
+      pointer-events: none;
+    }
+    .tapzone {
+      flex: 1;
+      pointer-events: auto;
+      -webkit-tap-highlight-color: transparent;
+    }
+    /* Only activate tap zones on coarse pointers (touch devices). */
+    @media (hover: hover) and (pointer: fine) {
+      .tapzones { display: none; }
+    }
+
+    .overlay {
+      position: fixed;
+      left: 50%;
+      bottom: 22px;
+      transform: translate(-50%, 6px) scale(0.92);
+      filter: blur(6px);
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      padding: 4px;
+      background: #000;
+      color: #fff;
+      border-radius: 999px;
+      font-size: 12px;
+      font-feature-settings: "tnum" 1;
+      letter-spacing: 0.01em;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 260ms ease, transform 260ms cubic-bezier(.2,.8,.2,1), filter 260ms ease;
+      transform-origin: center bottom;
+      z-index: 2147483000;
+      user-select: none;
+    }
+    .overlay[data-visible] {
+      opacity: 1;
+      pointer-events: auto;
+      transform: translate(-50%, 0) scale(1);
+      filter: blur(0);
+    }
+
+    .btn {
+      appearance: none;
+      -webkit-appearance: none;
+      background: transparent;
+      border: 0;
+      margin: 0;
+      padding: 0;
+      color: inherit;
+      font: inherit;
+      cursor: default;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      height: 28px;
+      min-width: 28px;
+      border-radius: 999px;
+      color: rgba(255,255,255,0.72);
+      transition: background 140ms ease, color 140ms ease;
+      -webkit-tap-highlight-color: transparent;
+    }
+    .btn:hover { background: rgba(255,255,255,0.12); color: #fff; }
+    .btn:active { background: rgba(255,255,255,0.18); }
+    .btn:focus { outline: none; }
+    .btn:focus-visible { outline: none; }
+    .btn::-moz-focus-inner { border: 0; }
+    .btn svg { width: 14px; height: 14px; display: block; }
+    .btn.reset {
+      font-size: 11px;
+      font-weight: 500;
+      letter-spacing: 0.02em;
+      padding: 0 10px 0 12px;
+      gap: 6px;
+      color: rgba(255,255,255,0.72);
+    }
+    .btn.reset .kbd {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      min-width: 16px;
+      height: 16px;
+      padding: 0 4px;
+      font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+      font-size: 10px;
+      line-height: 1;
+      color: rgba(255,255,255,0.88);
+      background: rgba(255,255,255,0.12);
+      border-radius: 4px;
+    }
+
+    .count {
+      font-variant-numeric: tabular-nums;
+      color: #fff;
+      font-weight: 500;
+      padding: 0 8px;
+      min-width: 42px;
+      text-align: center;
+      font-size: 12px;
+    }
+    .count .sep { color: rgba(255,255,255,0.45); margin: 0 3px; font-weight: 400; }
+    .count .total { color: rgba(255,255,255,0.55); }
+
+    .divider {
+      width: 1px;
+      height: 14px;
+      background: rgba(255,255,255,0.18);
+      margin: 0 2px;
+    }
+
+    /* ── Print: one page per slide, no chrome ────────────────────────────
+       The screen layout stacks every slide at inset:0 inside a scaled
+       canvas; for print we want them in document flow at the authored
+       design size so the browser paginates one slide per sheet. The
+       @page size is set from the width/height attributes via the inline
+       <style id="deck-stage-print-page"> that connectedCallback injects
+       into <head> (the @page at-rule has no effect inside shadow DOM). */
+    @media print {
+      :host {
+        position: static;
+        inset: auto;
+        background: none;
+        overflow: visible;
+        color: inherit;
+      }
+      .stage { position: static; display: block; }
+      .canvas {
+        transform: none !important;
+        width: auto !important;
+        height: auto !important;
+        background: none;
+        will-change: auto;
+      }
+      ::slotted(*) {
+        position: relative !important;
+        inset: auto !important;
+        width: var(--deck-design-w) !important;
+        height: var(--deck-design-h) !important;
+        box-sizing: border-box !important;
+        opacity: 1 !important;
+        visibility: visible !important;
+        pointer-events: auto;
+        break-after: page;
+        page-break-after: always;
+        break-inside: avoid;
+        overflow: hidden;
+      }
+      ::slotted(*:last-child) {
+        break-after: auto;
+        page-break-after: auto;
+      }
+      .overlay, .tapzones { display: none !important; }
+    }
+  `;
+
+  class DeckStage extends HTMLElement {
+    static get observedAttributes() { return ['width', 'height', 'noscale']; }
+
+    constructor() {
+      super();
+      this._root = this.attachShadow({ mode: 'open' });
+      this._index = 0;
+      this._slides = [];
+      this._notes = [];
+      this._hideTimer = null;
+      this._mouseIdleTimer = null;
+      this._storageKey = STORAGE_PREFIX + (location.pathname || '/');
+
+      this._onKey = this._onKey.bind(this);
+      this._onResize = this._onResize.bind(this);
+      this._onSlotChange = this._onSlotChange.bind(this);
+      this._onMouseMove = this._onMouseMove.bind(this);
+      this._onTapBack = this._onTapBack.bind(this);
+      this._onTapForward = this._onTapForward.bind(this);
+    }
+
+    get designWidth() {
+      return parseInt(this.getAttribute('width'), 10) || DESIGN_W_DEFAULT;
+    }
+    get designHeight() {
+      return parseInt(this.getAttribute('height'), 10) || DESIGN_H_DEFAULT;
+    }
+
+    connectedCallback() {
+      this._render();
+      this._loadNotes();
+      this._syncPrintPageRule();
+      window.addEventListener('keydown', this._onKey);
+      window.addEventListener('resize', this._onResize);
+      window.addEventListener('mousemove', this._onMouseMove, { passive: true });
+      // Initial collection + layout happens via slotchange, which fires on mount.
+    }
+
+    disconnectedCallback() {
+      window.removeEventListener('keydown', this._onKey);
+      window.removeEventListener('resize', this._onResize);
+      window.removeEventListener('mousemove', this._onMouseMove);
+      if (this._hideTimer) clearTimeout(this._hideTimer);
+      if (this._mouseIdleTimer) clearTimeout(this._mouseIdleTimer);
+    }
+
+    attributeChangedCallback() {
+      if (this._canvas) {
+        this._canvas.style.width = this.designWidth + 'px';
+        this._canvas.style.height = this.designHeight + 'px';
+        this._canvas.style.setProperty('--deck-design-w', this.designWidth + 'px');
+        this._canvas.style.setProperty('--deck-design-h', this.designHeight + 'px');
+        this._fit();
+        this._syncPrintPageRule();
+      }
+    }
+
+    _render() {
+      const style = document.createElement('style');
+      style.textContent = stylesheet;
+
+      const stage = document.createElement('div');
+      stage.className = 'stage';
+
+      const canvas = document.createElement('div');
+      canvas.className = 'canvas';
+      canvas.style.width = this.designWidth + 'px';
+      canvas.style.height = this.designHeight + 'px';
+      canvas.style.setProperty('--deck-design-w', this.designWidth + 'px');
+      canvas.style.setProperty('--deck-design-h', this.designHeight + 'px');
+
+      const slot = document.createElement('slot');
+      slot.addEventListener('slotchange', this._onSlotChange);
+      canvas.appendChild(slot);
+      stage.appendChild(canvas);
+
+      // Tap zones (mobile): left third = back, right third = forward.
+      const tapzones = document.createElement('div');
+      tapzones.className = 'tapzones export-hidden';
+      tapzones.setAttribute('aria-hidden', 'true');
+      const tzBack = document.createElement('div');
+      tzBack.className = 'tapzone tapzone--back';
+      const tzMid = document.createElement('div');
+      tzMid.className = 'tapzone tapzone--mid';
+      tzMid.style.pointerEvents = 'none';
+      const tzFwd = document.createElement('div');
+      tzFwd.className = 'tapzone tapzone--fwd';
+      tzBack.addEventListener('click', this._onTapBack);
+      tzFwd.addEventListener('click', this._onTapForward);
+      tapzones.append(tzBack, tzMid, tzFwd);
+
+      // Overlay: compact, solid black, with clickable controls.
+      const overlay = document.createElement('div');
+      overlay.className = 'overlay export-hidden';
+      overlay.setAttribute('role', 'toolbar');
+      overlay.setAttribute('aria-label', 'Deck controls');
+      overlay.innerHTML = `
+        <button class="btn prev" type="button" aria-label="Previous slide" title="Previous (←)">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M10 3L5 8l5 5"/></svg>
+        </button>
+        <span class="count" aria-live="polite"><span class="current">1</span><span class="sep">/</span><span class="total">1</span></span>
+        <button class="btn next" type="button" aria-label="Next slide" title="Next (→)">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 3l5 5-5 5"/></svg>
+        </button>
+        <span class="divider"></span>
+        <button class="btn reset" type="button" aria-label="Reset to first slide" title="Reset (R)">Reset<span class="kbd">R</span></button>
+      `;
+
+      overlay.querySelector('.prev').addEventListener('click', () => this._go(this._index - 1, 'click'));
+      overlay.querySelector('.next').addEventListener('click', () => this._go(this._index + 1, 'click'));
+      overlay.querySelector('.reset').addEventListener('click', () => this._go(0, 'click'));
+
+      this._root.append(style, stage, tapzones, overlay);
+      this._canvas = canvas;
+      this._slot = slot;
+      this._overlay = overlay;
+      this._countEl = overlay.querySelector('.current');
+      this._totalEl = overlay.querySelector('.total');
+    }
+
+    /** @page must live in the document stylesheet — it's a no-op inside
+     *  shadow DOM. Inject/update a single <head> style tag so the print
+     *  sheet matches the design size and Save-as-PDF yields one slide per
+     *  page with no margins. */
+    _syncPrintPageRule() {
+      const id = 'deck-stage-print-page';
+      let tag = document.getElementById(id);
+      if (!tag) {
+        tag = document.createElement('style');
+        tag.id = id;
+        document.head.appendChild(tag);
+      }
+      tag.textContent =
+        '@page { size: ' + this.designWidth + 'px ' + this.designHeight + 'px; margin: 0; } ' +
+        '@media print { html, body { margin: 0 !important; padding: 0 !important; background: none !important; overflow: visible !important; height: auto !important; } ' +
+        '* { -webkit-print-color-adjust: exact; print-color-adjust: exact; } }';
+    }
+
+    _onSlotChange() {
+      this._collectSlides();
+      this._restoreIndex();
+      this._applyIndex({ showOverlay: false, broadcast: true, reason: 'init' });
+      this._fit();
+    }
+
+    _collectSlides() {
+      const assigned = this._slot.assignedElements({ flatten: true });
+      this._slides = assigned.filter((el) => {
+        // Skip template/style/script nodes even if someone slots them.
+        const tag = el.tagName;
+        return tag !== 'TEMPLATE' && tag !== 'SCRIPT' && tag !== 'STYLE';
+      });
+
+      this._slides.forEach((slide, i) => {
+        const n = i + 1;
+        // Determine a label for comment flow: prefer explicit data-label,
+        // then an existing data-screen-label, then first heading, else "Slide".
+        let label = slide.getAttribute('data-label');
+        if (!label) {
+          const existing = slide.getAttribute('data-screen-label');
+          if (existing) {
+            // Strip any leading number the author may have included.
+            label = existing.replace(/^\s*\d+\s*/, '').trim() || existing;
+          }
+        }
+        if (!label) {
+          const h = slide.querySelector('h1, h2, h3, [data-title]');
+          if (h) label = (h.textContent || '').trim().slice(0, 40);
+        }
+        if (!label) label = 'Slide';
+        slide.setAttribute('data-screen-label', `${pad2(n)} ${label}`);
+
+        // Validation attribute for comment flow / auto-checks.
+        if (!slide.hasAttribute('data-om-validate')) {
+          slide.setAttribute('data-om-validate', VALIDATE_ATTR);
+        }
+
+        slide.setAttribute('data-deck-slide', String(i));
+      });
+
+      if (this._totalEl) this._totalEl.textContent = String(this._slides.length || 1);
+      if (this._index >= this._slides.length) this._index = Math.max(0, this._slides.length - 1);
+    }
+
+    _loadNotes() {
+      const tag = document.getElementById('speaker-notes');
+      if (!tag) { this._notes = []; return; }
+      try {
+        const parsed = JSON.parse(tag.textContent || '[]');
+        if (Array.isArray(parsed)) this._notes = parsed;
+      } catch (e) {
+        console.warn('[deck-stage] Failed to parse #speaker-notes JSON:', e);
+        this._notes = [];
+      }
+    }
+
+    _restoreIndex() {
+      try {
+        const raw = localStorage.getItem(this._storageKey);
+        if (raw != null) {
+          const n = parseInt(raw, 10);
+          if (Number.isFinite(n) && n >= 0 && n < this._slides.length) {
+            this._index = n;
+          }
+        }
+      } catch (e) { /* ignore */ }
+    }
+
+    _persistIndex() {
+      try { localStorage.setItem(this._storageKey, String(this._index)); }
+      catch (e) { /* ignore */ }
+    }
+
+    _applyIndex({ showOverlay = true, broadcast = true, reason = 'init' } = {}) {
+      if (!this._slides.length) return;
+      const prev = this._prevIndex == null ? -1 : this._prevIndex;
+      const curr = this._index;
+      this._slides.forEach((s, i) => {
+        if (i === curr) s.setAttribute('data-deck-active', '');
+        else s.removeAttribute('data-deck-active');
+      });
+      if (this._countEl) this._countEl.textContent = String(curr + 1);
+      this._persistIndex();
+
+      if (broadcast) {
+        // (1) Legacy: host-window postMessage for speaker-notes renderers.
+        try { window.postMessage({ slideIndexChanged: curr }, '*'); } catch (e) {}
+
+        // (2) In-page CustomEvent on the <deck-stage> element itself.
+        //     Bubbles and composes out of shadow DOM so slide code can listen:
+        //       document.querySelector('deck-stage').addEventListener('slidechange', e => {
+        //         e.detail.index, e.detail.previousIndex, e.detail.total, e.detail.slide, e.detail.reason
+        //       });
+        const detail = {
+          index: curr,
+          previousIndex: prev,
+          total: this._slides.length,
+          slide: this._slides[curr] || null,
+          previousSlide: prev >= 0 ? (this._slides[prev] || null) : null,
+          reason: reason, // 'init' | 'keyboard' | 'click' | 'tap' | 'api'
+        };
+        this.dispatchEvent(new CustomEvent('slidechange', {
+          detail,
+          bubbles: true,
+          composed: true,
+        }));
+      }
+
+      this._prevIndex = curr;
+      if (showOverlay) this._flashOverlay();
+    }
+
+    _flashOverlay() {
+      if (!this._overlay) return;
+      this._overlay.setAttribute('data-visible', '');
+      if (this._hideTimer) clearTimeout(this._hideTimer);
+      this._hideTimer = setTimeout(() => {
+        this._overlay.removeAttribute('data-visible');
+      }, OVERLAY_HIDE_MS);
+    }
+
+    _fit() {
+      if (!this._canvas) return;
+      // PPTX export sets noscale so the DOM capture sees authored-size
+      // geometry — the scaled canvas is in shadow DOM, so the exporter's
+      // resetTransformSelector can't reach .canvas.style.transform directly.
+      if (this.hasAttribute('noscale')) {
+        this._canvas.style.transform = 'none';
+        return;
+      }
+      const vw = window.innerWidth;
+      const vh = window.innerHeight;
+      const s = Math.min(vw / this.designWidth, vh / this.designHeight);
+      this._canvas.style.transform = `scale(${s})`;
+    }
+
+    _onResize() { this._fit(); }
+
+    _onMouseMove() {
+      // Keep overlay visible while mouse moves; hide after idle.
+      this._flashOverlay();
+    }
+
+    _onTapBack(e) {
+      e.preventDefault();
+      this._go(this._index - 1, 'tap');
+    }
+
+    _onTapForward(e) {
+      e.preventDefault();
+      this._go(this._index + 1, 'tap');
+    }
+
+    _onKey(e) {
+      // Ignore when the user is typing.
+      const t = e.target;
+      if (t && (t.isContentEditable || /^(INPUT|TEXTAREA|SELECT)$/.test(t.tagName))) return;
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+
+      const key = e.key;
+      let handled = true;
+
+      if (key === 'ArrowRight' || key === 'PageDown' || key === ' ' || key === 'Spacebar') {
+        this._go(this._index + 1, 'keyboard');
+      } else if (key === 'ArrowLeft' || key === 'PageUp') {
+        this._go(this._index - 1, 'keyboard');
+      } else if (key === 'Home') {
+        this._go(0, 'keyboard');
+      } else if (key === 'End') {
+        this._go(this._slides.length - 1, 'keyboard');
+      } else if (key === 'r' || key === 'R') {
+        this._go(0, 'keyboard');
+      } else if (/^[0-9]$/.test(key)) {
+        // 1..9 jump to that slide; 0 jumps to 10.
+        const n = key === '0' ? 9 : parseInt(key, 10) - 1;
+        if (n < this._slides.length) this._go(n, 'keyboard');
+      } else {
+        handled = false;
+      }
+
+      if (handled) {
+        e.preventDefault();
+        this._flashOverlay();
+      }
+    }
+
+    _go(i, reason = 'api') {
+      if (!this._slides.length) return;
+      const clamped = Math.max(0, Math.min(this._slides.length - 1, i));
+      if (clamped === this._index) {
+        this._flashOverlay();
+        return;
+      }
+      this._index = clamped;
+      this._applyIndex({ showOverlay: true, broadcast: true, reason });
+    }
+
+    // Public API ------------------------------------------------------------
+
+    /** Current slide index (0-based). */
+    get index() { return this._index; }
+    /** Total slide count. */
+    get length() { return this._slides.length; }
+    /** Programmatically navigate. */
+    goTo(i) { this._go(i, 'api'); }
+    next() { this._go(this._index + 1, 'api'); }
+    prev() { this._go(this._index - 1, 'api'); }
+    reset() { this._go(0, 'api'); }
+  }
+
+  if (!customElements.get('deck-stage')) {
+    customElements.define('deck-stage', DeckStage);
+  }
+})();
+
+</script>
+<style>
+  :root{
+    --bg:#05101c;
+    --bg-2:#071827;
+    --ink:#e9f1fb;
+    --ink-dim:#8aa0b6;
+    --ink-mute:#5c748b;
+    --line:#1b2f44;
+    --line-2:#24405e;
+    --cyan:#4fd1ff;
+    --cyan-dim:#6faacb;
+    --amber:#ffb454;
+    --red:#ff5f6d;
+    --green:#4cd99a;
+    --grid-color: rgba(79,209,255,.06);
+  }
+  html, body { margin:0; background:#000; color:var(--ink); font-family:'Inter',sans-serif; }
+  *{box-sizing:border-box;}
+  ::selection{background:var(--cyan); color:#001018;}
+
+  deck-stage section{
+    background: radial-gradient(circle at 70% 10%, #0a2238 0%, #05101c 55%, #030811 100%);
+    color:var(--ink);
+    font-family:'Inter',sans-serif;
+    overflow:hidden;
+    position:relative;
+  }
+
+  /* ——— Global scaffolding ——— */
+  .hud-frame{
+    position:absolute; inset:0;
+    pointer-events:none;
+    background:
+      linear-gradient(var(--grid-color) 1px, transparent 1px) 0 0/80px 80px,
+      linear-gradient(90deg, var(--grid-color) 1px, transparent 1px) 0 0/80px 80px;
+    mask-image: radial-gradient(circle at 60% 50%, #000 40%, transparent 75%);
+    -webkit-mask-image: radial-gradient(circle at 60% 50%, #000 40%, transparent 75%);
+  }
+  .corner{
+    position:absolute; width:36px; height:36px; border:1px solid var(--cyan);
+    opacity:.55;
+  }
+  .corner.tl{ top:56px; left:56px; border-right:none; border-bottom:none;}
+  .corner.tr{ top:56px; right:56px; border-left:none; border-bottom:none;}
+  .corner.bl{ bottom:56px; left:56px; border-right:none; border-top:none;}
+  .corner.br{ bottom:56px; right:56px; border-left:none; border-top:none;}
+
+  .rail{
+    position:absolute; inset:56px 0 56px 56px;
+    width:2px; background: linear-gradient(var(--line-2), transparent);
+  }
+
+  .tag{
+    font-family:'JetBrains Mono',monospace;
+    font-size:24px; letter-spacing:.22em; text-transform:uppercase;
+    color:var(--cyan); display:inline-flex; align-items:center; gap:14px;
+  }
+  .tag::before{
+    content:''; width:10px; height:10px; background:var(--cyan);
+    box-shadow:0 0 18px var(--cyan);
+    animation: blink 1.6s ease-in-out infinite;
+  }
+  @keyframes blink{ 0%,100%{opacity:1;} 50%{opacity:.35;} }
+
+  .footer{
+    position:absolute; left:100px; right:100px; bottom:36px;
+    display:flex; justify-content:space-between; align-items:center;
+    font-family:'JetBrains Mono',monospace;
+    font-size:24px; color:var(--ink-mute); letter-spacing:.18em;
+    text-transform:uppercase; z-index:5;
+  }
+  .footer .dot{ color:var(--cyan); animation:blink 2s infinite; }
+
+  h1.title-main{
+    font-family:'Space Grotesk',sans-serif;
+    font-weight:700;
+    font-size:140px;
+    line-height:.95;
+    letter-spacing:-.03em;
+    margin:0;
+  }
+  h2.slide-title{
+    font-family:'Space Grotesk',sans-serif;
+    font-weight:600;
+    font-size:84px;
+    line-height:1;
+    letter-spacing:-.02em;
+    margin:0;
+  }
+  .kicker{
+    font-family:'JetBrains Mono',monospace;
+    font-size:24px; letter-spacing:.3em;
+    color:var(--cyan); text-transform:uppercase; margin-bottom:32px;
+  }
+
+  /* ——— Slide 1: Title / HUD ——— */
+  .s-title{
+    padding:100px;
+    display:flex; flex-direction:column; justify-content:space-between;
+  }
+  .s-title .callsign{
+    font-family:'JetBrains Mono',monospace;
+    font-size:24px; letter-spacing:.3em; color:var(--cyan);
+  }
+  .s-title .hero{
+    display:flex; align-items:flex-end; gap:64px; margin-top:-40px;
+  }
+  .s-title .hero-left{ flex:1; }
+  .s-title h1{
+    font-family:'Space Grotesk',sans-serif;
+    font-weight:700; font-size:340px; line-height:.82;
+    letter-spacing:-.05em; margin:0;
+    color:var(--ink);
+    position:relative;
+  }
+  .s-title h1 .o{
+    color:var(--cyan);
+    text-shadow: 0 0 40px rgba(79,209,255,.5);
+  }
+  .s-title .subline{
+    font-family:'Space Grotesk',sans-serif;
+    font-size:44px; font-weight:400; color:var(--ink-dim);
+    margin-top:24px; letter-spacing:-.01em;
+  }
+  .s-title .subline b{ color:var(--ink); font-weight:600; }
+
+  .hud-panel{
+    width:520px; height:520px; position:relative;
+    border:1px solid var(--cyan); border-radius:50%;
+    display:flex; align-items:center; justify-content:center;
+    flex-shrink:0;
+  }
+  .hud-panel::before,
+  .hud-panel::after{
+    content:''; position:absolute; inset:24px;
+    border:1px dashed rgba(79,209,255,.4); border-radius:50%;
+  }
+  .hud-panel::after{ inset:100px; border-style:solid; border-color:rgba(79,209,255,.18); }
+  .hud-panel .radar{
+    position:absolute; inset:0;
+    background: conic-gradient(from 0deg, transparent 0deg, rgba(79,209,255,.5) 30deg, transparent 60deg);
+    border-radius:50%;
+    animation: rotate 4s linear infinite;
+    mix-blend-mode:screen;
+  }
+  @keyframes rotate{ to{ transform:rotate(360deg);} }
+  .hud-panel .center-stat{
+    text-align:center; z-index:2; position:relative;
+  }
+  .hud-panel .center-stat .big{
+    font-family:'Space Grotesk',sans-serif;
+    font-size:120px; font-weight:700; color:var(--cyan);
+    line-height:1; letter-spacing:-.03em;
+  }
+  .hud-panel .center-stat .label{
+    font-family:'JetBrains Mono',monospace;
+    font-size:24px; letter-spacing:.3em; color:var(--ink-dim);
+    text-transform:uppercase; margin-top:10px;
+  }
+  .hud-panel .tick{
+    position:absolute; top:6px; left:50%;
+    width:2px; height:18px; background:var(--cyan); transform-origin: 1px 254px;
+  }
+
+  .roster{
+    display:flex; gap:48px;
+  }
+  .roster .card{
+    border:1px solid var(--line-2);
+    padding:28px 32px;
+    background: rgba(7,24,39,.6);
+    backdrop-filter: blur(4px);
+    min-width:320px;
+  }
+  .roster .card .role{
+    font-family:'JetBrains Mono',monospace;
+    font-size:24px; letter-spacing:.2em; color:var(--cyan);
+    text-transform:uppercase; margin-bottom:10px;
+  }
+  .roster .card .name{
+    font-family:'Space Grotesk',sans-serif;
+    font-size:40px; font-weight:600; color:var(--ink); letter-spacing:-.01em;
+  }
+  .roster .card .tag-sm{
+    font-size:24px; color:var(--ink-mute); margin-top:6px;
+    font-family:'JetBrains Mono',monospace; letter-spacing:.12em;
+  }
+
+  /* ——— Slide 2: The Challenge ——— */
+  .s-challenge{
+    padding:90px 140px 150px;
+    display:flex; flex-direction:column; justify-content:center; gap:48px;
+  }
+  .stat-row{
+    display:grid; grid-template-columns:repeat(3,1fr); gap:0;
+    border-top:1px solid var(--line-2); border-bottom:1px solid var(--line-2);
+  }
+  .stat-row .stat{
+    padding:40px 44px;
+    border-right:1px solid var(--line-2);
+    position:relative;
+  }
+  .stat-row .stat:last-child{ border-right:none; }
+  .stat .num{
+    font-family:'Space Grotesk',sans-serif;
+    font-size:150px; font-weight:700; color:var(--cyan);
+    line-height:.85; letter-spacing:-.05em;
+  }
+  .stat .num small{ font-size:48px; color:var(--ink-dim); font-weight:400; margin-left:10px;}
+  .stat .caption{
+    font-family:'Inter',sans-serif;
+    font-size:24px; color:var(--ink-dim); margin-top:18px; line-height:1.3;
+  }
+  .stat .caption b{ color:var(--ink); font-weight:600; }
+
+  .challenge-hero{
+    font-family:'Space Grotesk',sans-serif;
+    font-size:78px; font-weight:600; line-height:1.05;
+    letter-spacing:-.02em; max-width:1500px;
+  }
+  .challenge-hero span{ color:var(--cyan); }
+
+  /* ——— Slide 3: What we built ——— */
+  .s-built{
+    padding:90px 120px 160px;
+    display:grid; grid-template-columns: 1fr 1fr; gap:100px;
+  }
+  .built-left{ display:flex; flex-direction:column; justify-content:center; gap:40px; }
+  .feature-list{ list-style:none; margin:0; padding:0; }
+  .feature-list li{
+    display:flex; align-items:flex-start; gap:32px;
+    padding:16px 0; border-bottom:1px solid var(--line);
+  }
+  .feature-list li:last-child{ border-bottom:none; }
+  .feature-list .code{
+    font-family:'JetBrains Mono',monospace;
+    font-size:24px; color:var(--cyan); width:84px; flex-shrink:0;
+    letter-spacing:.1em;
+  }
+  .feature-list .desc{
+    flex:1;
+  }
+  .feature-list .desc .t{
+    font-family:'Space Grotesk',sans-serif;
+    font-size:30px; font-weight:600; color:var(--ink);
+    letter-spacing:-.01em;
+  }
+  .feature-list .desc .d{
+    font-size:24px; color:var(--ink-dim); margin-top:6px; line-height:1.35;
+  }
+
+  /* Map / KML rendering */
+  .map-panel{
+    position:relative;
+    border:1px solid var(--line-2);
+    background: linear-gradient(180deg, #081a2b, #051321);
+    aspect-ratio: 1 / 1;
+    overflow:hidden;
+  }
+  .map-panel .mgrid{
+    position:absolute; inset:0;
+    background:
+      linear-gradient(rgba(79,209,255,.08) 1px, transparent 1px) 0 0/40px 40px,
+      linear-gradient(90deg, rgba(79,209,255,.08) 1px, transparent 1px) 0 0/40px 40px;
+  }
+  .map-panel svg{ position:absolute; inset:0; width:100%; height:100%; }
+  .map-panel .legend{
+    position:absolute; top:24px; left:24px; right:24px;
+    display:flex; justify-content:space-between; font-family:'JetBrains Mono',monospace;
+    font-size:14px; letter-spacing:.2em; color:var(--cyan); text-transform:uppercase;
+    opacity:.8;
+  }
+  .map-panel .coord{
+    position:absolute; bottom:24px; left:24px; right:24px;
+    display:flex; justify-content:space-between; font-family:'JetBrains Mono',monospace;
+    font-size:14px; color:var(--ink-mute); letter-spacing:.12em;
+  }
+  .map-panel .ping{
+    position:absolute; width:14px; height:14px; border-radius:50%;
+    background:var(--cyan); box-shadow:0 0 18px var(--cyan);
+    transform: translate(-50%,-50%);
+  }
+  .map-panel .ping::after{
+    content:''; position:absolute; inset:-8px; border-radius:50%;
+    border:1px solid var(--cyan); animation: pulse 2.2s ease-out infinite;
+  }
+  @keyframes pulse{ 0%{transform:scale(.6); opacity:1;} 100%{transform:scale(3); opacity:0;} }
+  .route-path{
+    fill:none; stroke:var(--cyan); stroke-width:2.5;
+    filter: drop-shadow(0 0 6px rgba(79,209,255,.7));
+    stroke-dasharray: 2000;
+    stroke-dashoffset: 2000;
+  }
+  section[data-deck-active] .route-path{
+    animation: draw 4s cubic-bezier(.6,0,.2,1) .4s forwards;
+  }
+  @keyframes draw{ to{ stroke-dashoffset:0; } }
+
+  /* ——— Slide 4: Stack / Architecture ——— */
+  .s-stack{
+    padding:120px 140px 140px;
+    display:flex; flex-direction:column; gap:80px;
+  }
+  .arch{
+    display:grid; grid-template-columns: 1fr 1fr 1fr 1fr; gap:32px;
+    align-items:stretch;
+  }
+  .node{
+    background: rgba(7,24,39,.6);
+    border:1px solid var(--line-2);
+    padding:32px;
+    position:relative;
+    min-height:280px;
+    display:flex; flex-direction:column; justify-content:space-between;
+    transition: transform .5s ease, border-color .5s ease, box-shadow .5s ease;
+  }
+  .node:hover{ border-color:var(--cyan); box-shadow:0 0 40px rgba(79,209,255,.15); transform: translateY(-4px);}
+  .node .idx{
+    font-family:'JetBrains Mono',monospace;
+    font-size:14px; letter-spacing:.3em; color:var(--cyan);
+  }
+  .node .name{
+    font-family:'Space Grotesk',sans-serif;
+    font-size:44px; font-weight:600; color:var(--ink);
+    letter-spacing:-.01em; margin-top:16px; line-height:1;
+  }
+  .node .tech{
+    font-size:18px; color:var(--ink-dim); margin-top:12px; line-height:1.45;
+  }
+  .node .meta{
+    font-family:'JetBrains Mono',monospace;
+    font-size:14px; color:var(--cyan-dim);
+    margin-top:20px; letter-spacing:.1em;
+  }
+  .arch-arrow{
+    position:absolute; right:-22px; top:50%; transform:translateY(-50%);
+    color:var(--cyan); font-family:'JetBrains Mono',monospace; font-size:24px;
+    z-index:2; text-shadow:0 0 8px var(--cyan);
+  }
+  .node:last-child .arch-arrow{ display:none; }
+
+  .stack-bottom{
+    display:grid; grid-template-columns: repeat(6,1fr); gap:24px;
+  }
+  .chip{
+    border:1px solid var(--line-2);
+    padding:20px 18px;
+    background: rgba(7,24,39,.45);
+    text-align:center;
+  }
+  .chip .c-name{
+    font-family:'Space Grotesk',sans-serif;
+    font-size:22px; font-weight:600; color:var(--ink);
+  }
+  .chip .c-tag{
+    font-family:'JetBrains Mono',monospace;
+    font-size:13px; color:var(--cyan); letter-spacing:.2em;
+    text-transform:uppercase; margin-top:4px;
+  }
+
+  /* ——— Slide 5: Problems / Timeline ——— */
+  .s-turbulence{
+    padding:90px 140px 130px;
+    display:flex; flex-direction:column; gap:40px;
+  }
+  .timeline{
+    position:relative;
+    display:grid; grid-template-columns: repeat(4, 1fr); gap:32px;
+    margin-top:20px;
+  }
+  .timeline::before{
+    content:''; position:absolute; left:0; right:0; top:22px; height:2px;
+    background: repeating-linear-gradient(90deg, var(--cyan-dim) 0 12px, transparent 12px 24px);
+    opacity:.5;
+  }
+  .tl-node{
+    position:relative;
+    padding-top:58px;
+  }
+  .tl-node::before{
+    content:''; position:absolute; top:12px; left:0;
+    width:20px; height:20px; border-radius:50%;
+    background:var(--bg); border:2px solid var(--cyan);
+    box-shadow: 0 0 12px var(--cyan);
+  }
+  .tl-node.warn::before{ border-color:var(--amber); box-shadow:0 0 12px var(--amber); }
+  .tl-node.err::before{ border-color:var(--red); box-shadow:0 0 12px var(--red); }
+  .tl-node.ok::before{ border-color:var(--green); box-shadow:0 0 12px var(--green); background:var(--green);}
+  .tl-time{
+    font-family:'JetBrains Mono',monospace;
+    font-size:16px; letter-spacing:.22em; color:var(--cyan);
+    text-transform:uppercase; margin-bottom:12px;
+  }
+  .tl-node.warn .tl-time{ color:var(--amber); }
+  .tl-node.err .tl-time{ color:var(--red); }
+  .tl-node.ok .tl-time{ color:var(--green); }
+  .tl-head{
+    font-family:'Space Grotesk',sans-serif;
+    font-size:26px; font-weight:600; color:var(--ink); line-height:1.1;
+    letter-spacing:-.01em; margin-bottom:10px;
+  }
+  .tl-body{
+    font-size:17px; color:var(--ink-dim); line-height:1.5;
+  }
+  /* Stats strip (Slide 5) */
+  .stats-strip{
+    display:grid; grid-template-columns: repeat(4, 1fr);
+    border:1px solid var(--line-2);
+    background: linear-gradient(180deg, rgba(7,24,39,.55), rgba(7,24,39,.25));
+  }
+  .stats-strip .stat{
+    padding:30px 36px;
+    border-right:1px solid var(--line-2);
+    position:relative;
+  }
+  .stats-strip .stat:last-child{ border-right:0; }
+  .stats-strip .stat::before{
+    content:''; position:absolute; top:0; left:0;
+    width:40px; height:2px; background:var(--cyan);
+  }
+  .stats-strip .stat.warn::before{ background:var(--amber); }
+  .stats-strip .stat.err::before{ background:var(--red); }
+  .stats-strip .stat-label{
+    font-family:'JetBrains Mono',monospace;
+    font-size:13px; letter-spacing:.24em; color:var(--ink-dim);
+    text-transform:uppercase;
+  }
+  .stats-strip .stat-num{
+    font-family:'Space Grotesk',sans-serif;
+    font-size:82px; font-weight:600; line-height:1;
+    letter-spacing:-.03em; color:var(--ink);
+    margin-top:14px;
+    font-variant-numeric: tabular-nums;
+  }
+  .stats-strip .stat.warn .stat-num{ color:var(--amber); }
+  .stats-strip .stat.err .stat-num{ color:var(--red); }
+  .stats-strip .stat.cyan .stat-num{ color:var(--cyan); }
+  .stats-strip .stat-sub{
+    font-size:16px; color:var(--ink-dim); margin-top:10px; line-height:1.35;
+  }
+
+  /* ——— Slide 6: Wnioski ——— */
+  .s-lessons{
+    padding:120px 140px 140px;
+    display:flex; flex-direction:column; gap:60px;
+  }
+  .lessons-hero{
+    font-family:'Space Grotesk',sans-serif;
+    font-size:110px; font-weight:600; line-height:1.02;
+    letter-spacing:-.02em; color:var(--ink);
+    max-width:1500px;
+  }
+  .lessons-hero span{ color:var(--cyan); }
+  .lessons-grid{
+    display:grid; grid-template-columns: repeat(3,1fr); gap:40px;
+  }
+  .lesson{
+    border:1px solid var(--line-2);
+    padding:40px 36px;
+    background: rgba(7,24,39,.5);
+    position:relative;
+    transition: border-color .4s ease;
+  }
+  .lesson::before{
+    content:''; position:absolute; top:0; left:0; height:3px; width:60px;
+    background:var(--cyan);
+  }
+  .lesson .ln{
+    font-family:'JetBrains Mono',monospace;
+    font-size:14px; letter-spacing:.26em; color:var(--cyan);
+    text-transform:uppercase; margin-bottom:18px;
+  }
+  .lesson .lt{
+    font-family:'Space Grotesk',sans-serif;
+    font-size:38px; font-weight:600; color:var(--ink); line-height:1.05;
+    letter-spacing:-.01em; margin-bottom:14px;
+  }
+  .lesson .lb{
+    font-size:20px; color:var(--ink-dim); line-height:1.5;
+  }
+
+  .closing-strip{
+    display:flex; justify-content:space-between; align-items:center;
+    padding-top:24px; border-top:1px solid var(--line-2);
+    font-family:'JetBrains Mono',monospace;
+  }
+  .closing-strip .lhs{
+    color:var(--cyan); font-size:24px; letter-spacing:.25em; text-transform:uppercase;
+  }
+  .closing-strip .rhs{
+    color:var(--ink-dim); font-size:20px; letter-spacing:.2em;
+  }
+
+  /* ——— Entry animations ——— */
+  section[data-deck-active] .anim-up{
+    animation: up .9s cubic-bezier(.2,.8,.2,1) both;
+  }
+  section[data-deck-active] .anim-up.d1{ animation-delay:.15s; }
+  section[data-deck-active] .anim-up.d2{ animation-delay:.3s; }
+  section[data-deck-active] .anim-up.d3{ animation-delay:.45s; }
+  section[data-deck-active] .anim-up.d4{ animation-delay:.6s; }
+  section[data-deck-active] .anim-up.d5{ animation-delay:.75s; }
+  @keyframes up{
+    from{ opacity:0; transform: translateY(40px); filter: blur(8px); }
+    to  { opacity:1; transform: none; filter: blur(0); }
+  }
+
+  section[data-deck-active] .anim-fade{
+    animation: fd 1.1s ease both;
+  }
+  @keyframes fd{ from{opacity:0;} to{opacity:1;} }
+
+  section[data-deck-active] .counter{
+    animation: none;
+  }
+  .counter{ font-variant-numeric: tabular-nums; }
+
+  /* Scan line */
+  section::after{
+    content:'';
+    position:absolute; left:0; right:0; top:0; height:3px;
+    background: linear-gradient(90deg, transparent, var(--cyan), transparent);
+    opacity:.35;
+    animation: scan 9s ease-in-out infinite;
+    pointer-events:none;
+  }
+  @keyframes scan{
+    0%{ top:0; opacity:0;}
+    5%{ opacity:.45; }
+    95%{ opacity:.45; }
+    100%{ top:100%; opacity:0;}
+  }
+</style>
+</head>
+<body>
+
+<deck-stage width="1920" height="1080">
+
+  <!-- ============ SLIDE 1 — TITLE ============ -->
+  <section data-label="Title">
+    <div class="hud-frame"></div>
+    <div class="corner tl"></div><div class="corner tr"></div>
+    <div class="corner bl"></div><div class="corner br"></div>
+
+    <div class="s-title">
+      <div style="display:flex; justify-content:space-between; align-items:flex-start;">
+        <div class="tag anim-up">AERO · FLIGHT OPS SYSTEM</div>
+        <div class="callsign anim-up d1" style="text-align:right;">
+          CALLSIGN &nbsp;//&nbsp; DIRTY-13<br/>
+          <span style="color:var(--ink-mute)">HACKATHON · 48 H · PSE INNOWACJE</span>
+        </div>
+      </div>
+
+      <div class="hero">
+        <div class="hero-left">
+          <h1 class="anim-up d1">AER<span class="o">O</span></h1>
+          <div class="subline anim-up d2">
+            System do ewidencji operacji lotniczych i zleceń na&nbsp;lot helikopterem — <b>zbudowany w&nbsp;48 godzin przez dwóch non-developerów</b>, z&nbsp;LLM w&nbsp;roli programisty.
+          </div>
+        </div>
+        <div class="hud-panel anim-fade">
+          <div class="radar"></div>
+          <div class="center-stat">
+            <div class="big counter" data-target="48">0</div>
+            <div class="label">HOURS · 2 PEOPLE · 0 IDE</div>
+          </div>
+          <!-- tick marks -->
+          <script>/* ticks injected by JS */</script>
+        </div>
+      </div>
+
+      <div class="roster anim-up d3">
+        <div class="card">
+          <div class="role">Pilot 01 · SSDLC</div>
+          <div class="name">Mariusz Kędziora</div>
+          <div class="tag-sm">// non-developer</div>
+        </div>
+        <div class="card">
+          <div class="role">Pilot 02 · SysOps</div>
+          <div class="name">Mariusz Szustka</div>
+          <div class="tag-sm">// non-developer</div>
+        </div>
+        <div class="card" style="border-color: var(--cyan); background: rgba(79,209,255,.06);">
+          <div class="role" style="color:var(--ink)">Copilot · LLM</div>
+          <div class="name" style="color:var(--cyan)">Vibe-coding</div>
+          <div class="tag-sm" style="color:var(--cyan-dim);">// wrote the code</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="footer">
+      <div>AERO · TOWNHALL <span class="dot">●</span> 2026</div>
+      <div>01 / 06</div>
+    </div>
+  </section>
+
+  <!-- ============ SLIDE 2 — CHALLENGE ============ -->
+  <section data-label="Challenge">
+    <div class="hud-frame"></div>
+    <div class="corner tl"></div><div class="corner tr"></div>
+    <div class="corner bl"></div><div class="corner br"></div>
+
+    <div class="s-challenge">
+      <div class="anim-up">
+        <div class="kicker">// brief / mission</div>
+        <div class="challenge-hero">
+          Zbuduj pełen system dla <span>operacji lotniczych helikopterem</span> —&nbsp;z&nbsp;mapami, KML, rolami i&nbsp;walidacjami bezpieczeństwa.
+        </div>
+      </div>
+
+      <div class="stat-row anim-up d2">
+        <div class="stat">
+          <div class="num counter" data-target="48">0<small>h</small></div>
+          <div class="caption"><b>Dwa dni</b> hackathonu.<br/>Od pustego repo do działającej aplikacji.</div>
+        </div>
+        <div class="stat">
+          <div class="num counter" data-target="2">0</div>
+          <div class="caption"><b>Dwóch non-developerów</b>.<br/>SSDLC + SysOps. Nikt nie pisze produkcyjnego kodu na co dzień.</div>
+        </div>
+        <div class="stat">
+          <div class="num counter" data-target="0">0</div>
+          <div class="caption"><b>Zero ręcznego kodu</b>.<br/>Cała aplikacja została napisana przez modele LLM.</div>
+        </div>
+      </div>
+
+      <div class="anim-up d3" style="display:flex; gap:48px; flex-wrap:wrap; font-family:'JetBrains Mono',monospace; font-size:24px; color:var(--ink-dim); letter-spacing:.12em;">
+        <div><span style="color:var(--cyan);">PRD</span> → 15&nbsp;850 znaków specyfikacji</div>
+        <div><span style="color:var(--cyan);">ROLES</span> → 4 × RBAC</div>
+        <div><span style="color:var(--cyan);">VALIDATIONS</span> → 5 safety checks</div>
+        <div><span style="color:var(--cyan);">STATUSES</span> → 7 (ops) · 7 (orders)</div>
+      </div>
+    </div>
+
+    <div class="footer">
+      <div>02 · WYZWANIE <span class="dot">●</span></div>
+      <div>02 / 06</div>
+    </div>
+  </section>
+
+  <!-- ============ SLIDE 3 — WHAT WE BUILT ============ -->
+  <section data-label="What We Built">
+    <div class="hud-frame"></div>
+    <div class="corner tl"></div><div class="corner tr"></div>
+    <div class="corner bl"></div><div class="corner br"></div>
+
+    <div class="s-built">
+      <div class="built-left">
+        <div class="anim-up">
+          <div class="kicker">// delivered</div>
+          <h2 class="slide-title">Co działa.</h2>
+        </div>
+        <ul class="feature-list">
+          <li class="anim-up d1">
+            <div class="code">01</div>
+            <div class="desc">
+              <div class="t">Operacje lotnicze + import KML</div>
+              <div class="d">Parsowanie trasy, wyliczenie km, wizualizacja na OpenStreetMap przez Leaflet.</div>
+            </div>
+          </li>
+          <li class="anim-up d2">
+            <div class="code">02</div>
+            <div class="desc">
+              <div class="t">Zlecenia na lot · 5 walidacji blokujących</div>
+              <div class="d">Przegląd helikoptera, licencja pilota, szkolenia załogi, waga, zasięg — sprawdzane przy zapisie.</div>
+            </div>
+          </li>
+          <li class="anim-up d3">
+            <div class="code">03</div>
+            <div class="desc">
+              <div class="t">RBAC · 4 role · hidden menu</div>
+              <div class="d">Administrator, Planista, Nadzorujący, Pilot — każdy widzi tylko swoje sekcje.</div>
+            </div>
+          </li>
+          <li class="anim-up d4">
+            <div class="code">04</div>
+            <div class="desc">
+              <div class="t">Cykle życia: 7 statusów, audit trail</div>
+              <div class="d">Automatyczne przejścia statusów operacji po rozliczeniu zlecenia. Historia zmian na polach.</div>
+            </div>
+          </li>
+          <li class="anim-up d5">
+            <div class="code">05</div>
+            <div class="desc">
+              <div class="t">PL/EN i18n, Docker Compose, HTTPS</div>
+              <div class="d"><span style="font-family:'JetBrains Mono',monospace; color:var(--cyan)">docker compose up</span> → 5 serwisów, self-signed TLS, seed.</div>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <div class="built-right" style="display:flex; flex-direction:column; justify-content:center; gap:28px;">
+        <div class="map-panel anim-fade">
+          <div class="mgrid"></div>
+          <div class="legend">
+            <span>OP-2025-12020 · SKAN 3D</span>
+            <span>KML · 247 PTS</span>
+          </div>
+          <svg viewBox="0 0 600 600" preserveAspectRatio="none">
+            <!-- faint country outline -->
+            <path d="M90 180 L180 120 L290 110 L400 150 L490 210 L520 320 L470 430 L360 490 L230 480 L140 410 L80 300 Z"
+                  fill="rgba(79,209,255,.04)" stroke="rgba(79,209,255,.2)" stroke-width="1" />
+            <!-- KML route -->
+            <path class="route-path" d="
+              M 120 420
+              C 170 380, 200 360, 230 340
+              S 290 300, 310 260
+              C 330 220, 360 200, 400 210
+              S 460 240, 480 280
+              C 490 320, 470 360, 430 380
+              S 360 400, 320 430
+              C 280 460, 240 470, 200 460
+            " />
+            <!-- waypoints -->
+            <circle cx="120" cy="420" r="5" fill="#ffb454"/>
+            <circle cx="310" cy="260" r="4" fill="#4fd1ff"/>
+            <circle cx="400" cy="210" r="4" fill="#4fd1ff"/>
+            <circle cx="480" cy="280" r="4" fill="#4fd1ff"/>
+            <circle cx="320" cy="430" r="4" fill="#4fd1ff"/>
+            <circle cx="200" cy="460" r="5" fill="#4cd99a"/>
+          </svg>
+          <div class="ping" style="left:20%; top:70%;"></div>
+          <div class="ping" style="left:33.3%; top:76.7%; animation-delay:.8s;"></div>
+          <div class="coord">
+            <span>52.1697°N&nbsp;&nbsp;20.9673°E</span>
+            <span>DIST 312 KM · ETE 00:58</span>
+          </div>
+        </div>
+        <div style="display:grid; grid-template-columns: repeat(3,1fr); gap:16px;" class="anim-up d3">
+          <div class="chip"><div class="c-name">13</div><div class="c-tag">REST endpoints</div></div>
+          <div class="chip"><div class="c-name">10</div><div class="c-tag">DB tables</div></div>
+          <div class="chip"><div class="c-name">8</div><div class="c-tag">E2E spec files</div></div>
+        </div>
+      </div>
+    </div>
+
+    <div class="footer">
+      <div>03 · CO ZBUDOWALIŚMY <span class="dot">●</span></div>
+      <div>03 / 06</div>
+    </div>
+  </section>
+
+  <!-- ============ SLIDE 4 — STACK / ARCHITECTURE ============ -->
+  <section data-label="Stack & Architecture">
+    <div class="hud-frame"></div>
+    <div class="corner tl"></div><div class="corner tr"></div>
+    <div class="corner bl"></div><div class="corner br"></div>
+
+    <div class="s-stack">
+      <div class="anim-up">
+        <div class="kicker">// systems diagram</div>
+        <h2 class="slide-title">Stack i&nbsp;architektura.</h2>
+        <div style="font-size:28px; color:var(--ink-dim); margin-top:24px; max-width:1300px; line-height:1.45;">
+          Pięć serwisów w&nbsp;Docker Compose. Jedna komenda — cały system działa lokalnie na&nbsp;HTTPS.
+        </div>
+      </div>
+
+      <div class="arch">
+        <div class="node anim-up d1">
+          <div>
+            <div class="idx">01 · CLIENT</div>
+            <div class="name">React 18</div>
+            <div class="tech">TypeScript · Vite · Tailwind v4 · shadcn/ui · React Query · Leaflet · i18next</div>
+          </div>
+          <div class="meta">→ :80 via nginx</div>
+          <div class="arch-arrow">→</div>
+        </div>
+        <div class="node anim-up d2">
+          <div>
+            <div class="idx">02 · GATEWAY</div>
+            <div class="name">nginx</div>
+            <div class="tech">Reverse proxy · TLS termination · SPA fallback · /api → backend</div>
+          </div>
+          <div class="meta">:443 TLS</div>
+          <div class="arch-arrow">→</div>
+        </div>
+        <div class="node anim-up d3">
+          <div>
+            <div class="idx">03 · API</div>
+            <div class="name">FastAPI</div>
+            <div class="tech">Python 3.12 · SQLAlchemy async · Alembic · JWT · fastkml · geopy</div>
+          </div>
+          <div class="meta">:8000 uvicorn</div>
+          <div class="arch-arrow">→</div>
+        </div>
+        <div class="node anim-up d4">
+          <div>
+            <div class="idx">04 · DATA</div>
+            <div class="name">PostgreSQL 16</div>
+            <div class="tech">Async driver (asyncpg) · health-checked · auto-seed · volume-persisted</div>
+          </div>
+          <div class="meta">:5432</div>
+        </div>
+      </div>
+
+      <div class="stack-bottom anim-up d5">
+        <div class="chip"><div class="c-name">FastAPI</div><div class="c-tag">0.115</div></div>
+        <div class="chip"><div class="c-name">React</div><div class="c-tag">18</div></div>
+        <div class="chip"><div class="c-name">Postgres</div><div class="c-tag">16</div></div>
+        <div class="chip"><div class="c-name">Docker</div><div class="c-tag">compose</div></div>
+        <div class="chip"><div class="c-name">Playwright</div><div class="c-tag">E2E</div></div>
+        <div class="chip"><div class="c-name">Leaflet</div><div class="c-tag">OSM</div></div>
+      </div>
+    </div>
+
+    <div class="footer">
+      <div>04 · ARCHITEKTURA <span class="dot">●</span></div>
+      <div>04 / 06</div>
+    </div>
+  </section>
+
+  <!-- ============ SLIDE 5 — TURBULENCE / PROBLEMS ============ -->
+  <section data-label="Turbulence">
+    <div class="hud-frame"></div>
+    <div class="corner tl"></div><div class="corner tr"></div>
+    <div class="corner bl"></div><div class="corner br"></div>
+
+    <div class="s-turbulence">
+      <div class="anim-up">
+        <div class="kicker">// flight log · turbulence</div>
+        <h2 class="slide-title">Nie wszystko szło&nbsp;gładko.</h2>
+        <div style="font-size:24px; color:var(--ink-dim); margin-top:16px; max-width:1500px; line-height:1.4;">
+          Z&nbsp;każdej pętli wyciągaliśmy wnioski: lepszy prompt, mniejszy zakres, więcej kontekstu. <b style="color:var(--ink)">LLM potrafi dużo — ale człowiek musi prowadzić.</b>
+        </div>
+      </div>
+
+      <div class="stats-strip anim-up d1">
+        <div class="stat err">
+          <div class="stat-label">// issues</div>
+          <div class="stat-num counter" data-stat="issues" data-target="27">0</div>
+          <div class="stat-sub">zgłoszonych i&nbsp;zamkniętych bugów oraz blockerów</div>
+        </div>
+        <div class="stat cyan">
+          <div class="stat-label">// commits</div>
+          <div class="stat-num counter" data-stat="commits" data-target="312">0</div>
+          <div class="stat-sub">w&nbsp;48 godzin — średnio 1&nbsp;commit co&nbsp;~9&nbsp;minut</div>
+        </div>
+        <div class="stat">
+          <div class="stat-label">// backend tests</div>
+          <div class="stat-num counter" data-stat="backendTests" data-target="188">0</div>
+          <div class="stat-sub">pytest: RBAC matrix, CRUD, lifecycle, safety, KML</div>
+        </div>
+        <div class="stat warn">
+          <div class="stat-label">// e2e tests</div>
+          <div class="stat-num counter" data-stat="e2eTests" data-target="40">0</div>
+          <div class="stat-sub">Playwright: login, navigation, RBAC, flows, responsive</div>
+        </div>
+      </div>
+
+      <div class="timeline">
+        <div class="tl-node warn anim-up d1">
+          <div class="tl-time">T+04H · CONTEXT</div>
+          <div class="tl-head">LLM gubił PRD</div>
+          <div class="tl-body">Model zapominał wymagań po kilku iteracjach. Rozwiązanie: krótsze cykle, PRD wklejany do każdej sesji.</div>
+        </div>
+        <div class="tl-node err anim-up d2">
+          <div class="tl-time">T+14H · BUILD</div>
+          <div class="tl-head">Docker &amp; CORS</div>
+          <div class="tl-body">TLS, reverse proxy, CORS — klasyczna bitwa 2&nbsp;h o&nbsp;<span style="font-family:'JetBrains Mono',monospace; color:var(--cyan)">https://localhost</span>. Debugging &gt; coding.</div>
+        </div>
+        <div class="tl-node warn anim-up d3">
+          <div class="tl-time">T+26H · KML</div>
+          <div class="tl-head">Parser KML i&nbsp;geometria</div>
+          <div class="tl-body">Biblioteka fastkml nie zwracała tego, czego model oczekiwał. Trzeba było czytać kod, nie promptować.</div>
+        </div>
+        <div class="tl-node ok anim-up d4">
+          <div class="tl-time">T+46H · GREEN</div>
+          <div class="tl-head">E2E przechodzi</div>
+          <div class="tl-body">Playwright, pełny login → CRUD → status flow. Seed działa. HTTPS działa. Mapy się renderują.</div>
+        </div>
+      </div>
+
+      <div class="anim-up d5" style="margin-top:16px; padding:22px 30px; border:1px solid var(--line-2); background: rgba(7,24,39,.4); display:flex; align-items:center; gap:28px;">
+        <div style="font-family:'JetBrains Mono',monospace; color:var(--cyan); font-size:18px; letter-spacing:.2em; white-space:nowrap;">KEY TAKEAWAY</div>
+        <div style="font-family:'Space Grotesk',sans-serif; font-size:25px; font-weight:500; color:var(--ink); line-height:1.25;">
+          Vibe-coding to&nbsp;nie&nbsp;„zero pracy". To&nbsp;<span style="color:var(--cyan);">zmiana pracy</span> — z&nbsp;pisania kodu na&nbsp;kierowanie LLM-em: prompt, review, debug.
+        </div>
+      </div>
+    </div>
+
+    <div class="footer">
+      <div>05 · TURBULENCJE <span class="dot">●</span></div>
+      <div>05 / 06</div>
+    </div>
+  </section>
+
+  <!-- ============ SLIDE 6 — LESSONS / CLOSING ============ -->
+  <section data-label="Lessons">
+    <div class="hud-frame"></div>
+    <div class="corner tl"></div><div class="corner tr"></div>
+    <div class="corner bl"></div><div class="corner br"></div>
+
+    <div class="s-lessons">
+      <div class="anim-up">
+        <div class="kicker">// debrief</div>
+        <div class="lessons-hero">
+          Dwóch non-devów + LLM = <span>działający system</span> w&nbsp;weekend.
+        </div>
+      </div>
+
+      <div class="lessons-grid">
+        <div class="lesson anim-up d1">
+          <div class="ln">01 · SPEED</div>
+          <div class="lt">Prototyp w&nbsp;godzinach, nie&nbsp;tygodniach</div>
+          <div class="lb">To, co kiedyś było „discovery + MVP" na&nbsp;2&nbsp;sprinty, teraz można zobaczyć w&nbsp;działaniu tego samego dnia.</div>
+        </div>
+        <div class="lesson anim-up d2">
+          <div class="ln">02 · ROLES</div>
+          <div class="lt">Rola inżyniera się&nbsp;zmienia</div>
+          <div class="lb">Promptowanie, architektura, review, walidacja — nie&nbsp;pisanie bojlerplejtu. Dobre PRD wygrywa z&nbsp;dobrym IDE.</div>
+        </div>
+        <div class="lesson anim-up d3">
+          <div class="ln">03 · LIMITS</div>
+          <div class="lt">LLM nie&nbsp;jest magią</div>
+          <div class="lb">Context drift, halucynacje w&nbsp;integracjach, problemy z&nbsp;infrą — człowiek musi wiedzieć, kiedy przerwać prompt i&nbsp;otworzyć kod.</div>
+        </div>
+      </div>
+
+      <div class="closing-strip anim-up d4">
+        <div class="lhs">// AERO · Dirty-13 · 48h</div>
+        <div class="rhs">PYTANIA? <span style="color:var(--cyan);">●</span></div>
+      </div>
+    </div>
+
+    <div class="footer">
+      <div>06 · WNIOSKI <span class="dot">●</span></div>
+      <div>06 / 06</div>
+    </div>
+  </section>
+
+</deck-stage>
+
+<script>
+  // ── AERO stats (editable via Tweaks panel) ────────────────────
+  window.AERO_STATS = /*EDITMODE-BEGIN*/{
+    "issues": 75,
+    "commits": 134,
+    "backendTests": 165,
+    "e2eTests": 45
+  }/*EDITMODE-END*/;
+</script>
+<script>
+  // ── Tick marks around the HUD radar (slide 1) ────────────────
+  (function(){
+    const panel = document.querySelector('.hud-panel');
+    if (!panel) return;
+    for (let i = 0; i < 36; i++){
+      const t = document.createElement('div');
+      t.className = 'tick';
+      t.style.transform = `rotate(${i*10}deg)`;
+      t.style.opacity = (i % 3 === 0) ? '.9' : '.3';
+      if (i % 3 !== 0) t.style.height = '10px';
+      panel.appendChild(t);
+    }
+  })();
+
+  // ── Counter animation on slide activation ────────────────────
+  function runCounters(slide){
+    const els = slide.querySelectorAll('.counter');
+    els.forEach(el => {
+      // Prefer live value from AERO_STATS (via data-stat key), else data-target
+      let target;
+      const statKey = el.dataset.stat;
+      if (statKey && window.AERO_STATS && typeof window.AERO_STATS[statKey] === 'number') {
+        target = window.AERO_STATS[statKey];
+        el.dataset.target = target; // keep in sync
+      } else {
+        target = parseInt(el.dataset.target, 10);
+      }
+      if (isNaN(target)) return;
+      const suffix = el.querySelector('small') ? el.querySelector('small').outerHTML : '';
+      const dur = 1400;
+      const start = performance.now();
+      function tick(now){
+        const p = Math.min(1, (now - start) / dur);
+        const ease = 1 - Math.pow(1 - p, 3);
+        const val = Math.round(target * ease);
+        el.innerHTML = val + suffix;
+        if (p < 1) requestAnimationFrame(tick);
+      }
+      requestAnimationFrame(tick);
+    });
+  }
+
+  // Initial + on slide change
+  document.addEventListener('DOMContentLoaded', () => {
+    const stage = document.querySelector('deck-stage');
+    const init = () => {
+      const active = document.querySelector('deck-stage section[data-deck-active]');
+      if (active) runCounters(active);
+    };
+    setTimeout(init, 200);
+    stage.addEventListener('slidechange', (e) => {
+      if (e.detail && e.detail.slide) runCounters(e.detail.slide);
+    });
+  });
+</script>
+
+<!-- ── Tweaks panel (stats on slide 5) ────────────────────────── -->
+<style>
+  #tweaks-panel{
+    position:fixed; right:18px; bottom:18px; z-index:9999;
+    width:320px;
+    background:#0a1220; color:#e8f4ff;
+    border:1px solid rgba(64,224,224,.35);
+    font-family:'JetBrains Mono',monospace; font-size:13px;
+    box-shadow: 0 12px 40px rgba(0,0,0,.6), 0 0 0 1px rgba(64,224,224,.08) inset;
+    display:none;
+  }
+  #tweaks-panel.on{ display:block; }
+  #tweaks-panel .hd{
+    padding:12px 14px; border-bottom:1px solid rgba(64,224,224,.2);
+    display:flex; align-items:center; justify-content:space-between;
+    letter-spacing:.22em; text-transform:uppercase; font-size:12px;
+    color:#40e0e0;
+  }
+  #tweaks-panel .hd .dot{ width:8px; height:8px; border-radius:50%; background:#40e0e0; box-shadow:0 0 8px #40e0e0; display:inline-block; margin-right:8px; vertical-align:middle;}
+  #tweaks-panel .body{ padding:14px; display:flex; flex-direction:column; gap:12px; }
+  #tweaks-panel .row{ display:flex; flex-direction:column; gap:6px; }
+  #tweaks-panel .row label{
+    font-size:11px; letter-spacing:.2em; text-transform:uppercase; color:#8aa0b8;
+  }
+  #tweaks-panel .row input{
+    background:#050b15; color:#e8f4ff;
+    border:1px solid rgba(64,224,224,.25);
+    padding:8px 10px; font-family:inherit; font-size:14px;
+    outline:none;
+  }
+  #tweaks-panel .row input:focus{ border-color:#40e0e0; box-shadow:0 0 0 2px rgba(64,224,224,.15); }
+  #tweaks-panel .note{
+    font-size:10px; color:#5f7a95; line-height:1.4; letter-spacing:.04em;
+    padding-top:4px; border-top:1px dashed rgba(64,224,224,.12);
+  }
+</style>
+
+<div id="tweaks-panel" aria-hidden="true">
+  <div class="hd"><span><span class="dot"></span>TWEAKS · STATS</span><span style="color:#5f7a95;">SLIDE 05</span></div>
+  <div class="body">
+    <div class="row">
+      <label>Issues</label>
+      <input type="number" min="0" id="tw-issues" />
+    </div>
+    <div class="row">
+      <label>Commits</label>
+      <input type="number" min="0" id="tw-commits" />
+    </div>
+    <div class="row">
+      <label>Backend tests</label>
+      <input type="number" min="0" id="tw-backendTests" />
+    </div>
+    <div class="row">
+      <label>E2E tests</label>
+      <input type="number" min="0" id="tw-e2eTests" />
+    </div>
+    <div class="note">Zmiany aplikują się natychmiast. Przejdź na slajd 5, aby zobaczyć animację liczników.</div>
+  </div>
+</div>
+
+<script>
+  (function(){
+    const KEYS = ['issues','commits','backendTests','e2eTests'];
+    const panel = document.getElementById('tweaks-panel');
+    const inputs = Object.fromEntries(KEYS.map(k => [k, document.getElementById('tw-'+k)]));
+
+    // Seed inputs from current stats
+    function syncInputs(){
+      KEYS.forEach(k => {
+        if (inputs[k]) inputs[k].value = window.AERO_STATS[k];
+      });
+    }
+    syncInputs();
+
+    function applyStats(updates){
+      Object.assign(window.AERO_STATS, updates);
+      // Update DOM counters immediately (without re-animating)
+      document.querySelectorAll('.counter[data-stat]').forEach(el => {
+        const k = el.dataset.stat;
+        if (updates[k] != null) {
+          el.dataset.target = updates[k];
+          el.textContent = updates[k];
+        }
+      });
+    }
+
+    KEYS.forEach(k => {
+      if (!inputs[k]) return;
+      inputs[k].addEventListener('input', () => {
+        const v = parseInt(inputs[k].value, 10);
+        if (isNaN(v) || v < 0) return;
+        const update = {}; update[k] = v;
+        applyStats(update);
+        // Persist
+        try {
+          window.parent.postMessage({type: '__edit_mode_set_keys', edits: update}, '*');
+        } catch(e) {}
+      });
+    });
+
+    // Edit-mode lifecycle — register listener FIRST, then announce.
+    window.addEventListener('message', (e) => {
+      const d = e.data || {};
+      if (d.type === '__activate_edit_mode') {
+        panel.classList.add('on');
+        panel.setAttribute('aria-hidden','false');
+        syncInputs();
+      } else if (d.type === '__deactivate_edit_mode') {
+        panel.classList.remove('on');
+        panel.setAttribute('aria-hidden','true');
+      }
+    });
+
+    try {
+      window.parent.postMessage({type: '__edit_mode_available'}, '*');
+    } catch(e) {}
+  })();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Prezentacja na townhall zaprojektowana przez użytkownika w **Claude Design** (claude.ai/design) i wyeksportowana jako handoff bundle. 6 slajdów (tytuł + 5 treściowych), 15 min, aesthetic aviation/cockpit HUD.

Zastępuje zamkniętego PR #106 (ręcznie składana wersja nie trafiła w oczekiwania).

## Slides

1. **Tytuł** — AERO z HUD radarem, callsigny, roster (Mariusz K + Mariusz S + LLM jako Copilot)
2. **Wyzwanie** — 48h · 2 non-devs · 0 ręcznego kodu, animowane liczniki
3. **Co zbudowaliśmy** — feature list + animowana mapa z rysującą się trasą KML
4. **Stack & architektura** — 4 węzły pipeline + chipy technologii
5. **Turbulencje** — timeline problemów (warn/err/ok) + strip ze statystykami
6. **Wnioski** — 3 karty (speed / roles / limits) + closing

## Design system

- **Kolor:** navy `#0a1628` + electric cyan (radar/HUD)
- **Fonts:** Space Grotesk (headings) + JetBrains Mono (technical) + Inter (body)
- **Animacje:** radar pulse, KML trace drawing, scroll reveal, typing effects, count-up liczników
- **Nawigacja:** ← → lub Space (next), R (reset), pozycja w localStorage
- **Tech:** standalone HTML, custom `<deck-stage>` web component inlined, zero frameworks

## Stats (slajd 5 — edytowalne via built-in Tweaks panel)

- **Issues:** 27 *(placeholder — do korekty przed townhallem)*
- **Commits:** 312 *(placeholder — do korekty przed townhallem)*
- **Backend tests:** 188 (pytest — RBAC matrix, CRUD, lifecycle, safety, KML)
- **E2E tests:** 40 (Playwright — login, navigation, RBAC, flows, responsive)

## Test plan

- [ ] Otworzyć `docs/AERO_Townhall.html` w Chrome — wszystkie 6 slajdów render
- [ ] Nawigacja: ← →, spacja, R (reset) działa
- [ ] Auto-scaling do viewport (1920×1080 design, letterbox)
- [ ] Animacje: radar pulse, KML trace drawing, counters animate
- [ ] Tweaks panel — edycja stats na slajdzie 5 zapisuje się do localStorage
- [ ] Print → Save as PDF daje clean one-page-per-slide
- [ ] Cross-browser: Firefox + Safari render match

## Notes

- Plik self-contained (~66 KB) — żadnych dependencies poza Google Fonts
- `<deck-stage>` web component inlined (ostrzeżenie o "space in filename" z oryginału rozwiązane przez rename do `AERO_Townhall.html`)
- Source bundle: Claude Design handoff z `api.anthropic.com/v1/design/h/KlMQqzfvE5dZUSbtNaNU4A`

## Related

- Closed: #106 (previous hand-coded version — archived, reopenable)

🤖 Handoff from [Claude Design](https://claude.ai/design)